### PR TITLE
Compile time Type based class composition in pure C++

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,3 +1,4 @@
+
 ## [Tabler Icons](https://tabler.io/icons)
 
 * Authors:
@@ -29,6 +30,7 @@ return FDate{ result.get<"year">(), result.get<"month">(), result.get<"day">() }
 
 In compile time non-the less! Unreal's own included Regex library pales in comparison.
 
+
 ## [magic_enum](https://github.com/Neargye/magic_enum)
 
 * Authors:
@@ -59,6 +61,31 @@ To have a "nice" declarative way to handle views for Unreal containers
 
 Reason of inclusion:  
 A YAML parser and emitter in C++. Unreal Engine doesn't provide one.
+
+## [constexpr-xxh3](https://github.com/chys87/constexpr-xxh3)
+
+* Authors:
+  * Chys (https://chys.info)
+* License: BSD 2-Clause License (https://github.com/chys87/constexpr-xxh3/blob/main/LICENSE)
+* [Source code](https://github.com/chys87/constexpr-xxh3)
+
+Reason of inclusion:  
+This allows us to have almost free runtime exact type checking.
+
+## [xxHash](https://xxhash.com)
+
+* Authors:
+  * Yann Collet (http://fastcompression.blogspot.fr/)
+  * Easy as PI 3.14 (https://github.com/easyaspi314)
+  * Takayuki Matsuoka
+  * et. al.
+* License: BSD 2-Clause License (https://github.com/Cyan4973/xxHash/blob/dev/LICENSE)
+* [Source code](https://github.com/Cyan4973/xxHash)
+
+Reason of inclusion:  
+xxHash algorithm is used by another third-party implementation in constexpr time. This allows us to have almost free
+runtime exact type checking.
+
 
 ## [Intel ISPC Tasksys](https://ispc.github.io)
 

--- a/Docs/Manual/Attribution.md
+++ b/Docs/Manual/Attribution.md
@@ -31,6 +31,7 @@ return FDate{ result.get<"year">(), result.get<"month">(), result.get<"day">() }
 
 In compile time non-the less! Unreal's own included Regex library pales in comparison.
 
+
 ## [magic_enum](https://github.com/Neargye/magic_enum)
 
 * Authors:
@@ -61,6 +62,31 @@ To have a "nice" declarative way to handle views for Unreal containers
 
 Reason of inclusion:  
 A YAML parser and emitter in C++. Unreal Engine doesn't provide one.
+
+## [constexpr-xxh3](https://github.com/chys87/constexpr-xxh3)
+
+* Authors:
+  * Chys (https://chys.info)
+* License: BSD 2-Clause License (https://github.com/chys87/constexpr-xxh3/blob/main/LICENSE)
+* [Source code](https://github.com/chys87/constexpr-xxh3)
+
+Reason of inclusion:  
+This allows us to have almost free runtime exact type checking.
+
+## [xxHash](https://xxhash.com)
+
+* Authors:
+  * Yann Collet (http://fastcompression.blogspot.fr/)
+  * Easy as PI 3.14 (https://github.com/easyaspi314)
+  * Takayuki Matsuoka
+  * et. al.
+* License: BSD 2-Clause License (https://github.com/Cyan4973/xxHash/blob/dev/LICENSE)
+* [Source code](https://github.com/Cyan4973/xxHash)
+
+Reason of inclusion:  
+xxHash algorithm is used by another third-party implementation in constexpr time. This allows us to have almost free
+runtime exact type checking.
+
 
 ## [Intel ISPC Tasksys](https://ispc.github.io)
 

--- a/Docs/Manual/index.md
+++ b/Docs/Manual/index.md
@@ -15,6 +15,12 @@ A C++23 utilities Unreal Engine proto-plugin, for a more civilized age.
 
 [Find the source code at](https://github.com/microdee/mcro)
 
+## Who is this library for?
+
+MCRO (pronounced 'em-cro') is made for C++ developers who may view Unreal Engine as a C++ framework first and as a content creation tool second. It is meant to support development of other plugins, so MCRO on its own has no primary purpose, but to provide building blocks for its dependant plugins.
+
+It also embraces quite elaborate C++ techniques involving templates and synergic combination of language features. The documentation also makes some effort explaining these techniques when used by MCRO, but the library users themselves don't need to go that deep, in order to enjoy many features of MCRO.
+
 ## What MCRO can do?
 
 Here are some code appetizers without going too deep into their details. The demonstrated features usually can do a lot more than what's shown here.
@@ -90,7 +96,7 @@ for (int i = 0; i < myKeyStrings.Num(); ++i)
 
 Notice how we didn't need to specify the TMap type, where both the key and value types were deduced from how the input ranges were manipulated before.
 
-Not yet impressed? No problem:
+Not yet impressed? May this snippet change that:
 
 ```Cpp
 TArray<int32> mySetCopy;
@@ -118,7 +124,7 @@ squares
 
 ```
 
-Notice how `RenderAs` could deduce the full type of `TSet` from its preceeding operations. This works with many Unreal container.
+Notice how `RenderAs` could deduce the full type of `TSet` from its preceeding operations. This works with many Unreal containers.
 
 This is just the very tip of the iceberg what this pattern of collection handling can introduce.
 
@@ -1008,6 +1014,8 @@ export void MakeLookupUV(
 ### Last but not least
 
 * [Dynamic ↔ Native (multicast) delegate interop](@ref Mcro/Delegates/AsNative.h)
+* [Native C++ class composition utilities](@ref Mcro/Composition.h)
+* [`FAny` cloning boost/STL `any` but for Unreal style](@ref Mcro/Any.h)
 * [Text interop and conversion utilities](@ref Mcro/Text.h)
 * [Object binding and promises for `AsyncTask`](@ref Mcro/Threading.h)
 * [Bullet-proof third-party library include guards.](@ref Mcro/LibraryIncludes/Start.h)

--- a/Doxyfile
+++ b/Doxyfile
@@ -101,7 +101,7 @@ CREATE_SUBDIRS         = YES
 # Minimum value: 0, maximum value: 8, default value: 8.
 # This tag requires that the tag CREATE_SUBDIRS is set to YES.
 
-CREATE_SUBDIRS_LEVEL   = 16
+CREATE_SUBDIRS_LEVEL   = 8
 
 # If the ALLOW_UNICODE_NAMES tag is set to YES, Doxygen will allow non-ASCII
 # characters to appear in the names of generated files. If set to NO, non-ASCII

--- a/Source/Mcro/McroWindows_Origin/Public/McroWindows/COM/Cast.h
+++ b/Source/Mcro/McroWindows_Origin/Public/McroWindows/COM/Cast.h
@@ -28,9 +28,9 @@ namespace Mcro::Windows::COM
 			return IError::Make(new FHresultError(hr, fastError))
 				->AsRecoverable()
 				->WithMessageF(
-					TEXT_"Object of type %s did not implement %s",
-					*TTypeString<From>,
-					*TTypeString<To>
+					TEXT_"Object of type {0} did not implement {1}",
+					TTypeName<From>,
+					TTypeName<To>
 				);
 		return Success();
 	}

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Any.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Any.cpp
@@ -1,0 +1,42 @@
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+ */
+
+#include "Mcro/Any.h"
+
+namespace Mcro::Any
+{
+	FAny::FAny(FAny const& other)
+	{
+		if (other.IsValid())
+			other.CopyConstruct(this, other);
+	}
+
+	FAny::FAny(FAny&& other)
+	{
+		if (other.IsValid())
+			other.MoveConstruct(this, Forward<FAny>(other));
+	}
+
+	FAny::~FAny()
+	{
+		if (static_cast<bool>(Destruct))
+			Destruct(this);
+	}
+
+	void FAny::CopyTypeInfo(FAny* self, const FAny* other)
+	{
+		self->MainType = other->MainType;
+		self->ValidTypes = other->ValidTypes;
+		self->CopyConstruct = other->CopyConstruct;
+		self->MoveConstruct = other->MoveConstruct;
+		self->Destruct = other->Destruct;
+	}
+}

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Any.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Any.cpp
@@ -30,6 +30,12 @@ namespace Mcro::Any
 		if (static_cast<bool>(Destruct))
 			Destruct(this);
 	}
+	
+	void FAny::AddAlias(FType const& alias)
+	{
+		if (!ValidTypes.Contains(alias))
+			ValidTypes.Add(alias);
+	}
 
 	void FAny::CopyTypeInfo(FAny* self, const FAny* other)
 	{

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Composition.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Composition.cpp
@@ -1,0 +1,79 @@
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+ */
+
+#include "Mcro/Composition.h"
+
+namespace Mcro::Composition
+{
+	bool IComposable::HasExactComponent(uint64 typeHash) const
+	{
+		return Components.Contains(typeHash);
+	}
+
+	bool IComposable::HasComponentAliasUnchecked(uint64 typeHash) const
+	{
+		return ComponentAliases.Contains(typeHash);
+	}
+
+	bool IComposable::HasComponentAlias(uint64 typeHash) const
+	{
+		if (HasComponentAliasUnchecked(typeHash))
+		{
+			TArray<uint64>& components = ComponentAliases[typeHash];
+			components.RemoveAll([this](uint64 i)
+			{
+				return !Components.Contains(i);
+			});
+			if (components.IsEmpty())
+			{
+				ComponentAliases.Remove(typeHash);
+				return false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	void IComposable::AddComponentAlias(uint64 mainType, uint64 validAs)
+	{
+		if (HasComponentAliasUnchecked(validAs))
+			ComponentAliases[validAs].Add(mainType);
+		else ComponentAliases.Add(validAs, { mainType });
+	}
+
+	ranges::any_view<FAny*> IComposable::GetExactComponent(uint64 typeHash) const
+	{
+		namespace r = ranges;
+		namespace rv = ranges::views;
+			
+		if (HasExactComponent(typeHash)) return rv::single(Components.Find(typeHash));
+		return ranges::empty_view<FAny*>();
+	}
+
+	ranges::any_view<FAny*> IComposable::GetAliasedComponents(uint64 typeHash) const
+	{
+		namespace r = ranges;
+		namespace rv = ranges::views;
+
+		auto asd = IComposable().WithComponent<FVector>();
+			
+		if (HasComponentAlias(typeHash))
+			return ComponentAliases[typeHash]
+				| rv::transform([this](uint64 i) -> decltype(auto) { return Components.Find(i); });
+			
+		return r::empty_view<FAny*>();
+	}
+
+	ranges::any_view<FAny*> IComposable::GetComponentsPrivate(uint64 typeHash) const
+	{
+		return GetExactComponent(typeHash) | Concat(GetAliasedComponents(typeHash));
+	}
+}

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Error.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Error.cpp
@@ -53,7 +53,7 @@ namespace Mcro::Error
 
 	void IError::AddError(const FString& name, const TSharedRef<IError>& error, const FString& typeOverride)
 	{
-		FString type = typeOverride.IsEmpty() ? error->GetType().ToString() : typeOverride;
+		FString type = typeOverride.IsEmpty() ? error->GetType().ToStringCopy() : typeOverride;
 		FString key = Join(TEXT_" ", type, name);
 		FString keyUnique = key;
 		for (int i = 1; i <= 100 && InnerErrors.Contains(keyUnique); ++i)

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Error/ErrorManager.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Error/ErrorManager.cpp
@@ -46,7 +46,7 @@ namespace Mcro::Error
 			args.bLogError,
 			LogErrorManager, Error,
 			TEXT_"Displaying error %s:",
-			*error->GetType().ToString()
+			*error->GetType().ToStringCopy()
 		);
 		ERROR_CLOG(args.bLogError && !bIsDisplayingError, LogErrorManager, Error, error);
 		if (args.bBreakDebugger)

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Any.Spec.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Any.Spec.cpp
@@ -1,0 +1,98 @@
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+ */
+
+#include "CoreMinimal.h"
+#include "TestHelpers.h"
+
+#include "Mcro/CommonCore.h"
+
+struct FAnyTestBase
+{
+	int A = 1;
+};
+
+struct FAnyTest : FAnyTestBase
+{
+	int B = 2;
+};
+
+DEFINE_SPEC(
+	FMcroAny_Spec,
+	TEXT_"Mcro.Any",
+	EAutomationTestFlags_ApplicationContextMask
+	| EAutomationTestFlags::CriticalPriority
+	| EAutomationTestFlags::ProductFilter
+);
+
+void FMcroAny_Spec::Define()
+{
+	using namespace Mcro::Common;
+
+	Describe(TEXT_"FAny", [this]
+	{
+		It(TEXT_"should respect type safety.", [this]
+		{
+			auto payload = FAny(new FAnyTest()).WithAlias<FAnyTestBase>();
+			
+			TestNotNull(TEXT_"Fetch with exact type", payload.TryGet<FAnyTest>());
+			TestNotNull(TEXT_"Fetch with alias type", payload.TryGet<FAnyTestBase>());
+			TestNull(TEXT_"Shouldn't allow unrelated types", payload.TryGet<FVector>());
+		});
+		
+		It(TEXT_"should be copyable/movable", [this]
+		{
+			auto payload = FAny(new FCopyConstructCounter());
+			check(payload.TryGet<FCopyConstructCounter>());
+			TestEqual(TEXT_"No initial copy", payload.TryGet<FCopyConstructCounter>()->CopyCount, 0);
+			TestEqual(TEXT_"No initial move", payload.TryGet<FCopyConstructCounter>()->MoveCount, 0);
+			FAny copy = payload;
+			check(copy.TryGet<FCopyConstructCounter>());
+			TestEqual(TEXT_"Copy once", copy.TryGet<FCopyConstructCounter>()->CopyCount, 1);
+		});
+		
+		It(TEXT_"should support object lifespan customization", [this]
+		{
+			TMap<int, FAnyTest> stupidPool { {1, FAnyTest{.B = 1}} };
+
+			{
+				TAnyTypeFacilities<FAnyTest> customLifespan
+				{
+					.Destruct = [&stupidPool](FAnyTest* i)
+					{
+						check(i);
+						stupidPool.Remove(i->B);
+					},
+					.CopyConstruct = [&stupidPool](FAnyTest const& i)
+					{
+						decltype(auto) result = stupidPool.Add(i.B + 1, FAnyTest{.B = i.B + 1});
+						return &result;
+					},
+					.MoveConstruct = [&stupidPool](FAnyTest&& i)
+					{
+						decltype(auto) result = stupidPool.Add(i.B + 1, FAnyTest{.B = i.B + 1});
+						return &result;
+					}
+				};
+				
+				auto payload = FAny(stupidPool.Find(1), customLifespan);
+				check(payload.TryGet<FAnyTest>());
+				TestEqual(TEXT_"No initial copy", stupidPool.Num(), 1);
+				{
+					FAny copy = payload;
+					check(copy.TryGet<FAnyTest>());
+					TestEqual(TEXT_"Copy once", stupidPool.Num(), 2);
+				}
+				TestEqual(TEXT_"Copy gone out of scope", stupidPool.Num(), 1);
+			}
+			TestEqual(TEXT_"Original gone out of scope", stupidPool.Num(), 0);
+		});
+	});
+}

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Any.Spec.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Any.Spec.cpp
@@ -14,15 +14,19 @@
 
 #include "Mcro/CommonCore.h"
 
-struct FAnyTestBase
+namespace Mcro::Test
 {
-	int A = 1;
-};
+	using namespace Mcro::Common;
+	
+	struct FAnyTestBase { int A = 1; };
+	struct FAnyTest : FAnyTestBase { int B = 2; };
 
-struct FAnyTest : FAnyTestBase
-{
-	int B = 2;
-};
+	struct IBaseA {};
+	struct IBaseB {};
+	struct IBaseC {};
+
+	struct FIntrusiveInherit : TInherit<IBaseA, IBaseB, IBaseC> {};
+}
 
 DEFINE_SPEC(
 	FMcroAny_Spec,
@@ -34,7 +38,7 @@ DEFINE_SPEC(
 
 void FMcroAny_Spec::Define()
 {
-	using namespace Mcro::Common;
+	using namespace Mcro::Test;
 
 	Describe(TEXT_"FAny", [this]
 	{
@@ -45,6 +49,16 @@ void FMcroAny_Spec::Define()
 			TestNotNull(TEXT_"Fetch with exact type", payload.TryGet<FAnyTest>());
 			TestNotNull(TEXT_"Fetch with alias type", payload.TryGet<FAnyTestBase>());
 			TestNull(TEXT_"Shouldn't allow unrelated types", payload.TryGet<FVector>());
+		});
+		
+		It(TEXT_"should use intrusive inheritance.", [this]
+		{
+			auto payload = FAny(new FIntrusiveInherit());
+			
+			TestNotNull(TEXT_"Fetch with exact type", payload.TryGet<FIntrusiveInherit>());
+			TestNotNull(TEXT_"Fetch with alias type A", payload.TryGet<IBaseA>());
+			TestNotNull(TEXT_"Fetch with alias type B", payload.TryGet<IBaseB>());
+			TestNotNull(TEXT_"Fetch with alias type C", payload.TryGet<IBaseC>());
 		});
 		
 		It(TEXT_"should be copyable/movable", [this]

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Composition.Spec.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Composition.Spec.cpp
@@ -1,0 +1,145 @@
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+ */
+
+#include "CoreMinimal.h"
+#include "TestHelpers.h"
+
+#include "Mcro/CommonCore.h"
+
+namespace Mcro::Test
+{
+	using namespace Mcro::Common;
+
+	struct FComposableSimple : IComposable
+	{
+		TFunction<void()> Confirmation;
+	};
+
+	struct FComposableOther : IComposable {};
+
+	struct FSharedComposable : IComposable, TSharedFromThis<FSharedComposable> {};
+	
+	struct IComponentInterface
+	{
+		int A = 0;
+	};
+
+	struct FComponentBase: IComponentInterface
+	{
+		int B = 1;
+	};
+
+	struct FComponentA: FComponentBase
+	{
+		int C = 2;
+	};
+
+	struct FComponentB: FComponentBase
+	{
+		int C = 3;
+	};
+
+	struct FComponentC: FComponentBase
+	{
+		int C = 4;
+	};
+
+	struct FSimpleComponent
+	{
+		int D = 3;
+	};
+
+	struct FChillComponent : IComponent 
+	{
+		void OnComponentRegistered(FComposableSimple& to) const
+		{
+			to.Confirmation();
+		}
+	};
+
+	struct FStrictComponent : IStrictComponent 
+	{
+		void OnComponentRegistered(FComposableSimple& to) const
+		{
+			to.Confirmation();
+		}
+	};
+}
+
+DEFINE_SPEC(
+	FMcroComposition_Spec,
+	TEXT_"Mcro.Composition",
+	EAutomationTestFlags_ApplicationContextMask
+	| EAutomationTestFlags::CriticalPriority
+	| EAutomationTestFlags::ProductFilter
+);
+
+void FMcroComposition_Spec::Define()
+{
+	using namespace Mcro::Common;
+	using namespace Mcro::Test;
+
+	Describe(TEXT_"IComposable", [this]
+	{
+		It(TEXT_"should respect type safety.", [this]
+		{
+			auto payload = FComposableSimple()
+				.WithComponent<FSimpleComponent>()
+				.WithComponent<FComponentA>().With(TAlias<FComponentBase, IComponentInterface>())
+				.WithComponent<FComponentB>().With(TAlias<FComponentBase, IComponentInterface>())
+				.WithComponent<FComponentC>().With(TAlias<FComponentBase, IComponentInterface>())
+			;
+			TestNotNull(TEXT_"FSimpleComponent", payload.TryGetComponent<FSimpleComponent>());
+			TestNotNull(TEXT_"FComponentA", payload.TryGetComponent<FComponentA>());
+			TestNotNull(TEXT_"FComponentB", payload.TryGetComponent<FComponentB>());
+			TestNotNull(TEXT_"FComponentC", payload.TryGetComponent<FComponentC>());
+			TestNull(TEXT_"Should return null for non-component", payload.TryGetComponent<FVector>());
+
+			auto components = payload.GetComponents<IComponentInterface>() | RenderAs<TArray>();
+			TestEqual(TEXT_"Getting multiple Components",  components.Num(), 3);
+		});
+		
+		It(TEXT_"should call OnComponentRegistered with supported components", [this]
+		{
+			namespace rv = ranges::views;
+			
+			int counter = 0;
+			auto payload = FComposableSimple { .Confirmation = [&counter]{ ++counter; } }
+				.WithComponent<FChillComponent>()
+				.WithComponent<FStrictComponent>()
+			;
+			TestEqual(TEXT_"OnComponentRegistered confirmation", counter, 2);
+
+			auto other = FComposableOther()
+				.WithComponent<FChillComponent>()
+				// .WithComponent<FStrictComponent>() // <- shouldn't compile
+			;
+		});
+		
+		It(TEXT_"should respect shared objects.", [this]
+		{
+			auto payload = MakeShared<FSharedComposable>()
+				->WithComponent<FSimpleComponent>()
+				->WithComponent<FComponentA>()->With(TAlias<FComponentBase, IComponentInterface>())
+				->WithComponent<FComponentB>()->With(TAlias<FComponentBase, IComponentInterface>())
+				->WithComponent<FComponentC>()->With(TAlias<FComponentBase, IComponentInterface>())
+			;
+			TestNotNull(TEXT_"FSimpleComponent", payload->TryGetComponent<FSimpleComponent>());
+			TestNotNull(TEXT_"FComponentA", payload->TryGetComponent<FComponentA>());
+			TestNotNull(TEXT_"FComponentB", payload->TryGetComponent<FComponentB>());
+			TestNotNull(TEXT_"FComponentC", payload->TryGetComponent<FComponentC>());
+			TestNull(TEXT_"Should return null for non-component", payload->TryGetComponent<FVector>());
+
+			auto components = payload->GetComponents<IComponentInterface>() | RenderAs<TArray>();
+			TestEqual(TEXT_"Getting multiple Components",  components.Num(), 3);
+		});
+	});
+}

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Error.Spec.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Error.Spec.cpp
@@ -129,7 +129,7 @@ DEFINE_SPEC(
 
 void FMcroErrorUI_Spec::Define()
 {
-	Describe(TEXT_"FErrorManager", [this]
+	xDescribe(TEXT_"FErrorManager", [this]
 	{
 		BeforeEach([]
 		{
@@ -184,7 +184,7 @@ void FMcroErrorUI_Spec::Define()
 		});
 	});
 
-	Describe(TEXT_"Assertions", [this]
+	xDescribe(TEXT_"Assertions", [this]
 	{
 		It(TEXT_"should crash app on assertion failure", [this]
 		{

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Error.Spec.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Error.Spec.cpp
@@ -101,7 +101,7 @@ void FMcroError_Spec::Define()
 			auto error = CommonTestError()
 				->AsRecoverable();
 			
-			TestEqual(TEXT_"Error Type", error->GetType(), NAME_"Mcro::Test::FTestSimpleError");
+			TestEqual(TEXT_"Error Type", error->GetTypeFName(), NAME_"Mcro::Test::FTestSimpleError");
 			TestEqual(TEXT_"Error Severity", error->GetSeverityString(), TEXTVIEW_"Recoverable");
 			TestEqual(TEXT_"Error Message", error->GetMessage(), STRING_"This is one test error");
 			TestEqual(TEXT_"Error Details", error->GetDetails(), STRING_

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/EventDelegate.Spec.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/EventDelegate.Spec.cpp
@@ -12,42 +12,9 @@
 #include "CoreMinimal.h"
 #include "Algo/Count.h"
 #include "Mcro/Common.h"
+#include "TestHelpers.h"
 
 using namespace Mcro::Common::With::InferDelegate;
-
-struct FCopyForbidden : FNoncopyable {};
-
-struct FCopyConstructCounter
-{
-	FCopyConstructCounter() {}
-	FCopyConstructCounter(FCopyConstructCounter const& other)
-		: CopyCount(other.CopyCount + 1)
-	{}
-	FCopyConstructCounter(FCopyConstructCounter&& other) noexcept
-		: MoveCount(other.MoveCount + 1)
-	{}
-
-	auto operator=(FCopyConstructCounter const& other) -> FCopyConstructCounter&
-	{
-		if (this == &other) return *this;
-
-		CopyAssignCount = other.CopyAssignCount + 1;
-		return *this;
-	}
-
-	auto operator=(FCopyConstructCounter&& other) noexcept -> FCopyConstructCounter&
-	{
-		if (this == &other) return *this;
-		
-		MoveAssignCount = other.MoveAssignCount + 1;
-		return *this;
-	}
-
-	int32 CopyCount = 0;
-	int32 MoveCount = 0;
-	int32 CopyAssignCount = 0;
-	int32 MoveAssignCount = 0;
-};
 
 DEFINE_SPEC(
 	FMcroEventDelegate_Spec,

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/TestHelpers.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/TestHelpers.cpp
@@ -1,0 +1,28 @@
+/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+*/
+
+#include "TestHelpers.h"
+
+auto FCopyConstructCounter::operator=(FCopyConstructCounter const& other) -> FCopyConstructCounter&
+{
+	if (this == &other) return *this;
+
+	CopyAssignCount = other.CopyAssignCount + 1;
+	return *this;
+}
+
+auto FCopyConstructCounter::operator=(FCopyConstructCounter&& other) noexcept -> FCopyConstructCounter&
+{
+	if (this == &other) return *this;
+		
+	MoveAssignCount = other.MoveAssignCount + 1;
+	return *this;
+}

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/TestHelpers.h
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/TestHelpers.h
@@ -1,0 +1,35 @@
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+*/
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct FCopyForbidden : FNoncopyable {};
+
+struct FCopyConstructCounter
+{
+	FORCEINLINE FCopyConstructCounter() {}
+	FORCEINLINE FCopyConstructCounter(FCopyConstructCounter const& other)
+		: CopyCount(other.CopyCount + 1)
+	{}
+	FORCEINLINE FCopyConstructCounter(FCopyConstructCounter&& other) noexcept
+		: MoveCount(other.MoveCount + 1)
+	{}
+
+	auto operator=(FCopyConstructCounter const& other) -> FCopyConstructCounter&;
+	auto operator=(FCopyConstructCounter&& other) noexcept -> FCopyConstructCounter&;
+
+	int32 CopyCount = 0;
+	int32 MoveCount = 0;
+	int32 CopyAssignCount = 0;
+	int32 MoveAssignCount = 0;
+};

--- a/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Types.spec.cpp
+++ b/Source/Mcro/Mcro_Origin/Private/Mcro/Tests/Types.spec.cpp
@@ -60,7 +60,7 @@ void FMcroTypes_Spec::Define()
 			name = FTestIncompleteScope::Test();
 			TestEqual(TEXT_"Confirm strictly scoped incompleteness", name, TEXT_"FTestIncompleteScope::Test::FIncomplete");
 			name = TTypeName<TTestTemplatedType<FMcroTypes_Spec>>;
-#if PLATFORM_WINDOWS
+#if MCRO_COMPILER_MSVC
 			TestEqual(TEXT_"Matches templated types", name, TEXT_"TTestTemplatedType<class FMcroTypes_Spec>");
 #else
 			TestEqual(TEXT_"Matches templated types", name, TEXT_"TTestTemplatedType<FMcroTypes_Spec>");

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Any.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Any.h
@@ -1,0 +1,141 @@
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+ */
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Mcro/TypeName.h"
+#include "Mcro/Concepts.h"
+
+namespace Mcro::Any
+{
+	using namespace Mcro::TypeName;
+	using namespace Mcro::Concepts;
+
+	struct FAny;
+
+	/**
+	 *	@brief
+	 *	Give the opportunity to customize object lifespan operations for `FAny` by either specializing this template
+	 *	or just providing functors in-place
+	 *	
+	 *	@tparam T  The type being set for an FAny
+	 */
+	template <typename T>
+	struct TAnyTypeFacilities
+	{
+		TFunction<void(T*)> Destruct {[](T* object)
+		{
+			delete object;
+		}};
+		
+		TFunction<T*(T const&)> CopyConstruct {[](T const& object)
+		{
+			return new T(object);
+		}};
+		
+		TFunction<T*(T&&)> MoveConstruct {[](T&& object)
+		{
+			return new T(Forward<T>(object));
+		}};
+	};
+
+	/**
+	 *	@brief
+	 *	A simplistic but type-safe and RAII compliant storage for anything. Enclosed data is owned by this type.
+	 *
+	 *	Use this with care, the underlying data can be only accessed with the same type as it has been constructed with,
+	 *	or with types provided by `ValidAs`. This means derived classes cannot be accessed with their base types safely
+	 *	and implicitly.
+	 *
+	 *	Enclosed value must be copy and move constructible and assignable.
+	 *
+	 *	@todo
+	 *	C++ 26 has promising proposal for static value-based reflection, which can gather metadata from classes
+	 *	or even emit them. The best summary I found so far is a stack-overflow answer https://stackoverflow.com/a/77477029
+	 *	Once that's available we can gather base classes in compile time, and do dynamic casting of objects without
+	 *	the need for intrusive extra syntax, or extra work at construction.
+	 *	Currently GCC's `__bases` would be perfect for the job, but other popular compilers don't have similar intrinsics.
+	 */
+	struct MCRO_API FAny
+	{
+		template <CCopyable T>
+		FAny(T* newObject, TAnyTypeFacilities<T> const& facilities = {})
+			: Storage(newObject)
+			, MainType(TTypeOf<T>)
+			, Destruct([facilities](FAny* self)
+			{
+				T* object = static_cast<T*>(self->Storage);
+				facilities.Destruct(object);
+				self->Storage = nullptr;
+			})
+			, CopyConstruct([facilities](FAny* self, FAny const& other)
+			{
+				const T* object = static_cast<const T*>(other.Storage);
+				self->Storage = facilities.CopyConstruct(*object);
+				
+				CopyTypeInfo(self, &other);
+			})
+			, MoveConstruct([facilities](FAny* self, FAny&& other)
+			{
+				T& object = *static_cast<T*>(other.Storage);
+				self->Storage = facilities.MoveConstruct(MoveTemp(object));
+				
+				CopyTypeInfo(self, &other);
+			})
+		{
+			ValidTypes.Add(MainType);
+		}
+
+		FORCEINLINE FAny() {}
+		FAny(FAny const& other);
+		FAny(FAny&& other);
+		~FAny();
+
+		template <typename T>
+		const T* TryGet() const
+		{
+			return ValidTypes.Contains(TTypeOf<T>)
+				? static_cast<const T*>(Storage)
+				: nullptr;
+		}
+
+		template <typename T>
+		T* TryGet()
+		{
+			return ValidTypes.Contains(TTypeOf<T>)
+				? static_cast<T*>(Storage)
+				: nullptr;
+		}
+
+		template <typename Self, typename... T>
+		decltype(auto) ValidAs(this Self&& self)
+		{
+			(ValidTypes.Add(TTypeOf<T>), ...);
+			return Forward<Self>(self);
+		}
+
+		FORCEINLINE bool IsValid() const { return static_cast<bool>(Storage); }
+		FORCEINLINE FType GetType() const { return MainType; }
+		FORCEINLINE TSet<FType> const& GetValidTypes() const { return ValidTypes; }
+		
+	private:
+		static void CopyTypeInfo(FAny* self, const FAny* other);
+		
+		FType MainType {};
+		TSet<FType> ValidTypes {};
+		void* Storage = nullptr;
+		
+		TFunction<void(FAny* self, FAny const& other)> CopyConstruct {};
+		TFunction<void(FAny* self, FAny&& other)> MoveConstruct {};
+		TFunction<void(FAny* self)> Destruct {};
+	};
+}

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/CommonCore.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/CommonCore.h
@@ -23,10 +23,12 @@
 
 #include "Mcro/ArrayViews.h"
 #include "Mcro/Badge.h"
+#include "Mcro/Composition.h"
 #include "Mcro/Concepts.h"
 #include "Mcro/Construct.h"
 #include "Mcro/Enums.h"
 #include "Mcro/Finally.h"
+#include "Mcro/FmtMacros.h"
 #include "Mcro/FunctionTraits.h"
 #include "Mcro/InitializeOnCopy.h"
 #include "Mcro/Once.h"
@@ -37,7 +39,6 @@
 #include "Mcro/Types.h"
 #include "Mcro/Void.h"
 #include "Mcro/TextMacros.h"
-#include "Mcro/FmtMacros.h"
 #include "Mcro/Range.h"
 #include "Mcro/Range/Conversion.h"
 #include "Mcro/Range/Views.h"
@@ -48,6 +49,7 @@ namespace Mcro::CommonCore
 {
 	using namespace Mcro::ArrayViews;
 	using namespace Mcro::Badge;
+	using namespace Mcro::Composition;
 	using namespace Mcro::Concepts;
 	using namespace Mcro::Construct;
 	using namespace Mcro::Enums;

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
@@ -25,14 +25,6 @@ namespace Mcro::Composition
 	using namespace Mcro::Any;
 	using namespace Mcro::Range;
 
-	/**
-	 *	@brief
-	 *	This template is used in `IComponent::With(TAlias<...>)` so it can have deduced this type and explicit
-	 *	variadic template arguments when specifying multiple aliases.
-	 */
-	template <typename...>
-	struct TAlias {};
-
 	class IComposable;
 
 	/**
@@ -160,7 +152,7 @@ namespace Mcro::Composition
 	 *	the need for intrusive extra syntax, or extra work at construction.
 	 *	Currently GCC's `__bases` would be perfect for the job, but other popular compilers don't have similar
 	 *	intrinsics. Once such a feature becomes widely available base classes can be automatically added as aliases for
-	 *	registered components
+	 *	registered components.
 	 */
 	class MCRO_API IComposable
 	{
@@ -176,7 +168,7 @@ namespace Mcro::Composition
 		template <typename ValidAs>
 		void AddComponentAlias(uint64 mainType)
 		{
-			Components[mainType].ValidAs<ValidAs>();
+			Components[mainType].WithAlias<ValidAs>();
 			AddComponentAlias(mainType, TTypeHash<ValidAs>);
 		}
 		
@@ -242,7 +234,7 @@ namespace Mcro::Composition
 		requires CCompatibleComponent<MainType, Self>
 		void AddComponent(this Self&& self, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
-			self.template AddComponent<MainType, Self>(new MainType(), facilities);
+			Forward<Self>(self).template AddComponent<MainType, Self>(new MainType(), facilities);
 		}
 
 		/**
@@ -292,7 +284,7 @@ namespace Mcro::Composition
 		requires CCompatibleComponent<MainType, Self>
 		auto WithComponent(this Self&& self, MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
-			self.template AddComponent<MainType, Self>(newComponent, facilities);
+			Forward<Self>(self).template AddComponent<MainType, Self>(newComponent, facilities);
 			return self.SharedThis(&self);
 		}
 		
@@ -316,7 +308,7 @@ namespace Mcro::Composition
 		requires CCompatibleComponent<MainType, Self>
 		auto WithComponent(this Self&& self, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
-			self.template AddComponent<MainType, Self>(facilities);
+			Forward<Self>(self).template AddComponent<MainType, Self>(facilities);
 			return self.SharedThis(&self);
 		}
 
@@ -345,7 +337,7 @@ namespace Mcro::Composition
 		requires (CCompatibleComponent<MainType, Self> && !CSharedFromThis<Self>)
 		decltype(auto) WithComponent(this Self&& self, MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
-			self.template AddComponent<MainType, Self>(newComponent, facilities);
+			Forward<Self>(self).template AddComponent<MainType, Self>(newComponent, facilities);
 			return Forward<Self>(self);
 		}
 
@@ -369,7 +361,7 @@ namespace Mcro::Composition
 		requires (CCompatibleComponent<MainType, Self> && !CSharedFromThis<Self>)
 		decltype(auto) WithComponent(this Self&& self, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
-			self.template AddComponent<MainType, Self>(facilities);
+			Forward<Self>(self).template AddComponent<MainType, Self>(facilities);
 			return Forward<Self>(self);
 		}
 
@@ -410,7 +402,7 @@ namespace Mcro::Composition
 		template <typename ValidAs, CSharedFromThis Self>
 		auto WithAlias(this Self&& self)
 		{
-			self.template AddAlias<ValidAs>();
+			Forward<Self>(self).template AddAlias<ValidAs>();
 			return self.SharedThis(&self);
 		}
 
@@ -452,7 +444,7 @@ namespace Mcro::Composition
 		requires (!CSharedFromThis<Self>)
 		decltype(auto) WithAlias(this Self&& self)
 		{
-			self.template AddAlias<ValidAs>();
+			Forward<Self>(self).template AddAlias<ValidAs>();
 			return Forward<Self>(self);
 		}
 
@@ -489,7 +481,7 @@ namespace Mcro::Composition
 		template <CSharedFromThis Self, typename... ValidAs>
 		auto With(this Self&& self, TAlias<ValidAs...>&&)
 		{
-			self.template AddAlias<ValidAs...>();
+			Forward<Self>(self).template AddAlias<ValidAs...>();
 			return self.SharedThis(&self);
 		}
 
@@ -527,7 +519,7 @@ namespace Mcro::Composition
 		requires (!CSharedFromThis<Self>)
 		decltype(auto) With(this Self&& self, TAlias<ValidAs...>&&)
 		{
-			self.template AddAlias<ValidAs...>();
+			Forward<Self>(self).template AddAlias<ValidAs...>();
 			return Forward<Self>(self);
 		}
 

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
@@ -15,140 +15,594 @@
 #include "Mcro/Any.h"
 #include "Mcro/TextMacros.h"
 #include "Mcro/AssertMacros.h"
+#include "Mcro/Range.h"
+#include "Mcro/Range/Views.h"
+#include "Mcro/Range/Conversion.h"
 
 /** @brief Namespace containing utilities and base classes for type composition */
 namespace Mcro::Composition
 {
 	using namespace Mcro::Any;
+	using namespace Mcro::Range;
 
 	/**
-	 *	@brief  
+	 *	@brief
+	 *	This template is used in `IComponent::With(TAlias<...>)` so it can have deduced this type and explicit
+	 *	variadic template arguments when specifying multiple aliases.
 	 */
-	class IHaveComponents
+	template <typename...>
+	struct TAlias {};
+
+	class IComposable;
+
+	/**
+	 *	@brief
+	 *	Inherit from this empty interface to signal that the inheriting class knows that it's a component and that it
+	 *	can receive info about the composable class it is being registered to.
+	 *
+	 *	Define `OnComponentRegistered(T& to)` in the inheriting class, where T is the expected type of the
+	 *	composable parent. In case this component is registered to a composable class which is not convertible to T
+	 *	then `OnComponentRegistered` will be silently ignored.
+	 */
+	struct IComponent
 	{
-		mutable TMap<uint64, TVariant<FAny, uint64>> Components;
+		// void OnComponentRegistered(T& to) {}
+	};
 
-		template <typename T>
-		bool HasExactComponent() const
+	/**
+	 *	@brief
+	 *	Inherit from this empty interface to signal that the inheriting class knows that it's a component and that it
+	 *	can receive info about the composable class it is being registered to.
+	 *
+	 *	Define `OnComponentRegistered(T& to)` in the inheriting class, where T is the expected type of the
+	 *	composable parent. In case of `IStrictComponent`, it is a compile error to register this class to a composable
+	 *	class which is not convertible to T.
+	 */
+	struct IStrictComponent : IComponent
+	{
+		// void OnComponentRegistered(T& to) {}
+	};
+
+	template <typename T>
+	concept CComposable = CDerivedFrom<T, IComposable>;
+
+	template <typename T>
+	concept CExplicitComponent = CDerivedFrom<T, IComponent>;
+
+	template <typename T>
+	concept CStrictComponent = CDerivedFrom<T, IStrictComponent>;
+	
+	template <typename T, typename Composition>
+	concept CCompatibleExplicitComponent = CExplicitComponent<T>
+		&& requires(std::decay_t<T>& t, Composition&& parent)
 		{
-			return Components.Contains(TTypeHash<T>) && Components[TTypeHash<T>].template IsType<FAny>();
+			t.OnComponentRegistered(parent);
 		}
+	;
 
-		template <typename T>
-		bool HasComponentAliasUnchecked() const
+	template <typename T, typename Composition>
+	concept CCompatibleStrictComponent = CStrictComponent<T> && CCompatibleExplicitComponent<T, Composition>;
+
+	template <typename T, typename Composition>
+	concept CCompatibleComponent = !CStrictComponent<T> || CCompatibleStrictComponent<T, Composition>;
+
+	/**
+	 *	@brief  A base class which can bring type based class-composition to a derived class
+	 *
+	 *	This exists because indeed Unreal has its own composition model (actors / actor-components) or it has the
+	 *	subsystem architecture for non-actors, they still require to be used with UObjects. `IComposable` allows
+	 *	any C++ objects to have type-safe runtime managed optional components which can be configured separately for
+	 *	each instance.
+	 *
+	 *	The only requirement for components is that they need to be copy and move constructible (as is the default with
+	 *	plain-old-C++ objects, if they don't have members where either constructors are deleted or inaccessible). This
+	 *	limitation is imposed by `FAny` only for easier interfacing, but the API for managing components will never move
+	 *	or copy them by itself.
+	 *	The composable class doesn't have that limitation.
+	 *
+	 *	Usage:
+	 *	@code
+	 *	struct IBaseComponent { int A; };
+	 *	
+	 *	struct FComponentImplementation : IBaseComponent
+	 *	{
+	 *		FComponentImplementation(int a, int b) : A(a), B(b) {}
+	 *		int B;
+	 *	};
+	 *	struct FSimpleComponent { int C; };
+	 *
+	 *	class FMyComposableType : public IComposable {};
+	 *
+	 *	FMyComposableType MyStuff()
+	 *		.WithComponent(new FComponentImplementation(1, 2)).WithAlias<IBaseComponent>()
+	 *		.WithComponent<FSimpleComponent>()
+	 *	;
+	 *	@endcode
+	 *
+	 *	As mentioned earlier, components are not required to have any arbitrary type traits, but if they inherit from
+	 *	`IComponent` or `IStrictComponent` they can receive extra information when they're registered for a composable
+	 *	class. The difference between the two is that `IComponent` doesn't mind if it's attached to a composable class
+	 *	it doesn't know about, however it is a compile error if an `IStrictComponent` is attempted to be attached to
+	 *	an incompatible class.
+	 *
+	 *	For example
+	 *	@code
+	 *	struct FChillComponent : IComponent
+	 *	{
+	 *		void OnComponentRegistered(FExpectedParent& to) {}
+	 *	};
+	 *	
+	 *	struct FStrictComponent : IStrictComponent
+	 *	{
+	 *		void OnComponentRegistered(FExpectedParent& to) {}
+	 *	};
+	 *
+	 *	class FExpectedParent : public IComposable {};
+	 *	class FSomeOtherParent : public IComposable {};
+	 *	
+	 *	auto MyOtherStuff = FExpectedParent()
+	 *		.WithComponent<FChillComponent>()  // OK, and OnComponentRegistered is called
+	 *		.WithComponent<FStrictComponent>() // OK, and OnComponentRegistered is called
+	 *
+	 *	auto MyStuff = FSomeOtherParent()
+	 *		.WithComponent<FChillComponent>()  // OK, but OnComponentRegistered won't be called.
+	 *		
+	 *		.WithComponent<FStrictComponent>() // COMPILE ERROR, CCompatibleComponent concept is not satisfied
+	 *		                                   // because FSomeOtherParent is not convertible to FExpectedParent
+	 *		                                   // at OnComponentRegistered(FExpectedParent& to)
+	 *	;
+	 *	@endcode
+	 *	
+	 *	@todo
+	 *	C++ 26 has promising proposal for static value-based reflection, which can gather metadata from classes
+	 *	or even emit them. The best summary I found so far is a stack-overflow answer https://stackoverflow.com/a/77477029
+	 *	Once that's available we can gather base classes in compile time, and do dynamic casting of objects without
+	 *	the need for intrusive extra syntax, or extra work at construction.
+	 *	Currently GCC's `__bases` would be perfect for the job, but other popular compilers don't have similar
+	 *	intrinsics. Once such a feature becomes widely available base classes can be automatically added as aliases for
+	 *	registered components
+	 */
+	class MCRO_API IComposable
+	{
+		uint64 LastAddedComponentHash = 0;
+		mutable TMap<uint64, FAny> Components;
+		mutable TMap<uint64, TArray<uint64>> ComponentAliases;
+
+		bool HasExactComponent(uint64 typeHash) const;
+		bool HasComponentAliasUnchecked(uint64 typeHash) const;
+		bool HasComponentAlias(uint64 typeHash) const;
+		void AddComponentAlias(uint64 mainType, uint64 validAs);
+		
+		template <typename ValidAs>
+		void AddComponentAlias(uint64 mainType)
 		{
-			return Components.Contains(TTypeHash<T>) && Components[TTypeHash<T>].template IsType<uint64>();
+			Components[mainType].ValidAs<ValidAs>();
+			AddComponentAlias(mainType, TTypeHash<ValidAs>);
 		}
-
-		template <typename T>
-		uint64 GetRealComponentHash() const
-		{
-			return HasExactComponent<T>()
-				? TTypeHash<T>
-				: HasComponentAliasUnchecked<T>()
-				? Components[TTypeHash<T>].template Get<uint64>()
-				: 0;
-		}
-
-		template <typename T>
-		bool HasComponentAlias() const
-		{
-			if (HasComponentAliasUnchecked<T>())
-			{
-				uint64 realComponent = GetRealComponentHash<T>();
-				if (Components.Contains(realComponent)) return true;
-				Components.Remove(TTypeHash<T>);
-			}
-			return false;
-		}
-
-		template <typename T>
-		const FAny* TryGetComponentPrivate() const
-		{
-			uint64 realComponent = GetRealComponentHash<T>();
-			if (const auto* variant = Components.Find(realComponent))
-				return &variant->Get<FAny>();
-			return nullptr;
-		}
-
-		template <typename T>
-		FAny* TryGetComponentPrivate()
-		{
-			uint64 realComponent = GetRealComponentHash<T>();
-			if (auto* variant = Components.Find(realComponent))
-				return &variant->Get<FAny>();
-			return nullptr;
-		}
-
-		template <typename MainType, typename ValidAs>
-		void AddComponentAlias()
-		{
-			if (!ensureMsgf(
-				!HasExactComponent<ValidAs>(),
-				TEXT_"%s won't be used with %s because a real component already exists under that type.",
-				*TTypeString<MainType>(),
-				*TTypeString<ValidAs>()
-			)) return;
-			
-			if (!ensureMsgf(
-				!HasComponentAlias<ValidAs>(),
-				TEXT_"%s won't be used with %s because another component %s already uses it as an alias.",
-				*TTypeString<MainType>(),
-				*TTypeString<ValidAs>(),
-				*TryGetComponentPrivate<ValidAs>()->GetType().ToStringCopy()
-			)) return;
-
-			Components.Add(TTypeHash<ValidAs>, {TInPlaceType<uint64>(), TTypeHash<MainType>});
-		}
-
+		
+		ranges::any_view<FAny*> GetExactComponent(uint64 typeHash) const;
+		ranges::any_view<FAny*> GetAliasedComponents(uint64 typeHash) const;
+		ranges::any_view<FAny*> GetComponentsPrivate(uint64 typeHash) const;
+		
 	public:
-		template <typename MainType, typename... ValidAs>
-		MainType& AddComponent(MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
+
+		/**
+		 *	@brief
+		 *	Add a component to this composable class.
+		 *
+		 *	@tparam MainType  The exact component type (deduced from `newComponent`
+		 *	@tparam Self      Deducing this
+		 *	@param  self      Deducing this
+		 *	
+		 *	@param newComponent
+		 *	A pointer to the new component being added. `IComposable` will assume ownership of the new component
+		 *	adhering to RAII. Make sure the lifespan of the provided object is not managed by something else or the
+		 *	stack, in fact better to stick with the `new` operator.
+		 *
+		 *	@param facilities
+		 *	Customization point for object copy/move and delete methods. See `TAnyTypeFacilities`
+		 */
+		template <typename MainType, typename Self>
+		requires CCompatibleComponent<MainType, Self>
+		void AddComponent(this Self&& self, MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
 			ASSERT_CRASH(newComponent);
-			ASSERT_CRASH(!HasExactComponent<MainType>(), ->WithMessageF(
-				TEXT_"{0} cannot be added because another component already exists under that type.",
-				TTypeName<MainType>
-			));
-			ASSERT_CRASH(!HasComponentAlias<MainType>(), ->WithMessageF(
-				TEXT_"{0} cannot be added because another component {1} already uses {0} as an alias.",
-				TTypeName<MainType>,
-				TryGetComponentPrivate<MainType>()->GetType()
-			));
+			ASSERT_CRASH(!self.HasExactComponent(TTypeHash<MainType>),
+				->WithMessageF(
+					TEXT_"{0} cannot be added because another component already exists under that type.",
+					TTypeName<MainType>
+				)
+				->WithDetailsF(TEXT_
+					"Try wrapping your component in an empty derived type, and register it with its base type {0} as its"
+					" alias. Later on both the current and the already existing component can be accessed via"
+					" `GetComponents<{0}>()` which returns a range of all matching components.",
+					TTypeName<MainType>
+				)
+			);
 			
-			Components.Add(TTypeHash<MainType>, {TInPlaceType<FAny>(), FAny(newComponent, facilities).ValidAs<ValidAs...>()});
-			(AddComponentAlias<MainType, ValidAs>(), ...);
-			return *newComponent;
+			self.Components.Add(TTypeHash<MainType>, FAny(newComponent, facilities));
+			self.LastAddedComponentHash = TTypeHash<MainType>;
+
+			if constexpr (CCompatibleExplicitComponent<MainType, Self>)
+				newComponent->OnComponentRegistered(self);
 		}
 		
-		template <CDefaultInitializable MainType, typename... ValidAs>
-		MainType& AddComponent(TAnyTypeFacilities<MainType> const& facilities = {})
+		/**
+		 *	@brief
+		 *	Add a default constructed component to this composable class. 
+		 *
+		 *	@tparam MainType  The exact component type
+		 *	@tparam Self      Deducing this
+		 *	@param  self      Deducing this
+		 *
+		 *	@param facilities
+		 *	Customization point for object copy/move and delete methods. See `TAnyTypeFacilities`
+		 */
+		template <CDefaultInitializable MainType, typename Self>
+		requires CCompatibleComponent<MainType, Self>
+		void AddComponent(this Self&& self, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
-			return AddComponent<MainType, ValidAs...>(new MainType(), facilities);
-		}
-		
-		template <CDefaultInitializable MainType, typename... ValidAs>
-		MainType& GetOrAddComponent(TAnyTypeFacilities<MainType> const& facilities = {})
-		{
-			return AddComponent<MainType, ValidAs...>(new MainType(), facilities);
+			self.template AddComponent<MainType, Self>(new MainType(), facilities);
 		}
 
+		/**
+		 *	@brief
+		 *	Add a list of types the last added component is convertible to and may be used to get the last component
+		 *	among others which may list the same aliases.
+		 *
+		 *	@warning
+		 *	Calling this function before adding a component may result in a runtime crash!
+		 *	
+		 *	@tparam ValidAs
+		 *	The list of other types the last added component is convertible to and may be used to get the last component
+		 *	among others which may list the same aliases.
+		 */
+		template <typename... ValidAs>
+		void AddAlias()
+		{
+			ASSERT_CRASH(LastAddedComponentHash != 0 && Components.Contains(LastAddedComponentHash),
+				->WithMessage(TEXT_"Component aliases were listed, but no components were added before.")
+				->WithDetails(TEXT_"Make sure `AddAlias` or `WithAlias` is called after `AddComponent` / `WithComponent`.")
+			);
+			(AddComponentAlias<ValidAs>(LastAddedComponentHash), ...);
+		}
+
+		/**
+		 *	@brief
+		 *	Add a component to this composable class with a fluent API.
+		 *
+		 *	This overload is available for composable classes which also inherit from `TSharedFromThis`.
+		 *
+		 *	@tparam MainType  The exact component type (deduced from `newComponent`
+		 *	@tparam Self      Deducing this
+		 *	@param  self      Deducing this
+		 *	
+		 *	@param newComponent
+		 *	A pointer to the new component being added. `IComposable` will assume ownership of the new component
+		 *	adhering to RAII. Make sure the lifespan of the provided object is not managed by something else or the
+		 *	stack, in fact better to stick with the `new` operator.
+		 *
+		 *	@param facilities
+		 *	Customization point for object copy/move and delete methods. See `TAnyTypeFacilities`
+		 *
+		 *	@return
+		 *	If the composable class also inherits from `TSharedFromThis` return a shared ref.
+		 */
+		template <typename MainType, CSharedFromThis Self>
+		requires CCompatibleComponent<MainType, Self>
+		auto WithComponent(this Self&& self, MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
+		{
+			self.template AddComponent<MainType, Self>(newComponent, facilities);
+			return self.SharedThis(&self);
+		}
+		
+		/**
+		 *	@brief
+		 *	Add a default constructed component to this composable class with a fluent API. 
+		 *
+		 *	This overload is available for composable classes which also inherit from `TSharedFromThis`.
+		 *
+		 *	@tparam MainType  The exact component type
+		 *	@tparam Self      Deducing this
+		 *	@param  self      Deducing this
+		 *
+		 *	@param facilities
+		 *	Customization point for object copy/move and delete methods. See `TAnyTypeFacilities`
+		 *
+		 *	@return
+		 *	If the composable class also inherits from `TSharedFromThis` return a shared ref.
+		 */
+		template <CDefaultInitializable MainType, CSharedFromThis Self>
+		requires CCompatibleComponent<MainType, Self>
+		auto WithComponent(this Self&& self, TAnyTypeFacilities<MainType> const& facilities = {})
+		{
+			self.template AddComponent<MainType, Self>(facilities);
+			return self.SharedThis(&self);
+		}
+
+		/**
+		 *	@brief
+		 *	Add a component to this composable class with a fluent API.
+		 *
+		 *	This overload is available for composable classes which are not explicitly meant to be used with shared pointers.
+		 *
+		 *	@tparam MainType  The exact component type (deduced from `newComponent`
+		 *	@tparam Self      Deducing this
+		 *	@param  self      Deducing this
+		 *	
+		 *	@param newComponent
+		 *	A pointer to the new component being added. `IComposable` will assume ownership of the new component
+		 *	adhering to RAII. Make sure the lifespan of the provided object is not managed by something else or the
+		 *	stack, in fact better to stick with the `new` operator.
+		 *
+		 *	@param facilities
+		 *	Customization point for object copy/move and delete methods. See `TAnyTypeFacilities`
+		 *
+		 *	@return
+		 *	Perfect-forwarded self.
+		 */
+		template <typename MainType, typename Self>
+		requires (CCompatibleComponent<MainType, Self> && !CSharedFromThis<Self>)
+		decltype(auto) WithComponent(this Self&& self, MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
+		{
+			self.template AddComponent<MainType, Self>(newComponent, facilities);
+			return Forward<Self>(self);
+		}
+
+		/**
+		 *	@brief
+		 *	Add a default constructed component to this composable class with a fluent API. 
+		 *
+		 *	This overload is available for composable classes which are not explicitly meant to be used with shared pointers.
+		 *
+		 *	@tparam MainType  The exact component type
+		 *	@tparam Self      Deducing this
+		 *	@param  self      Deducing this
+		 *
+		 *	@param facilities
+		 *	Customization point for object copy/move and delete methods. See `TAnyTypeFacilities`
+		 *
+		 *	@return
+		 *	Perfect-forwarded self.
+		 */
+		template <CDefaultInitializable MainType, typename Self>
+		requires (CCompatibleComponent<MainType, Self> && !CSharedFromThis<Self>)
+		decltype(auto) WithComponent(this Self&& self, TAnyTypeFacilities<MainType> const& facilities = {})
+		{
+			self.template AddComponent<MainType, Self>(facilities);
+			return Forward<Self>(self);
+		}
+
+		/**
+		 *	@brief
+		 *	Add a type, the last added component is convertible to and may be used to get the last component among
+		 *	others which may list the same aliases.
+		 *
+		 *	Only one alias may be specified this way because of templating syntax intricacies, but it may be called
+		 *	multiple times in a sequence to add multiple aliases for the same component.
+		 *
+		 *	Usage:
+		 *	@code
+		 *	auto result = IComposable()
+		 *		.WithComponent<FMyComponent>()
+		 *			.WithAlias<FMyComponentBase>()
+		 *			.WithAlias<IMyComponentInterface>()
+		 *	;
+		 *	@endcode
+		 *
+		 *	For declaring multiple aliases in one go, use `With(TAlias<...>)` member template method.
+		 *	
+		 *	This overload is available for composable classes which also inherit from `TSharedFromThis`.
+		 *
+		 *	@warning
+		 *	Calling this function before adding a component may result in a runtime crash!
+		 *	
+		 *	@tparam ValidAs
+		 *	A type, the last added component is convertible to and may be used to get the last component among others
+		 *	which may list the same aliases.
+		 *	
+		 *	@tparam Self  Deducing this
+		 *	@param  self  Deducing this
+		 *
+		 *	@return
+		 *	If the composable class also inherits from `TSharedFromThis` return a shared ref.
+		 */
+		template <typename ValidAs, CSharedFromThis Self>
+		auto WithAlias(this Self&& self)
+		{
+			self.template AddAlias<ValidAs>();
+			return self.SharedThis(&self);
+		}
+
+		/**
+		 *	@brief
+		 *	Add a type, the last added component is convertible to and may be used to get the last component among
+		 *	others which may list the same aliases.
+		 *
+		 *	Only one alias may be specified this way because of templating syntax intricacies, but it may be called
+		 *	multiple times in a sequence to add multiple aliases for the same component.
+		 *
+		 *	Usage:
+		 *	@code
+		 *	auto result = IComposable()
+		 *		.WithComponent<FMyComponent>()
+		 *			.WithAlias<FMyComponentBase>()
+		 *			.WithAlias<IMyComponentInterface>()
+		 *	;
+		 *	@endcode
+		 *
+		 *	For declaring multiple aliases in one go, use `With(TAlias<...>)` member template method.
+		 *	
+		 *	This overload is available for composable classes which are not explicitly meant to be used with shared pointers.
+		 *
+		 *	@warning
+		 *	Calling this function before adding a component may result in a runtime crash!
+		 *	
+		 *	@tparam ValidAs
+		 *	A type, the last added component is convertible to and may be used to get the last component among others
+		 *	which may list the same aliases.
+		 *	
+		 *	@tparam Self  Deducing this
+		 *	@param  self  Deducing this
+		 *
+		 *	@return
+		 *	Perfect-forwarded self.
+		 */
+		template <typename ValidAs, typename Self>
+		requires (!CSharedFromThis<Self>)
+		decltype(auto) WithAlias(this Self&& self)
+		{
+			self.template AddAlias<ValidAs>();
+			return Forward<Self>(self);
+		}
+
+		/**
+		 *	@brief
+		 *	Add a list of types the last added component is convertible to and may be used to get the last component
+		 *	among others which may list the same aliases.
+		 *
+		 *	Usage:
+		 *	@code
+		 *	auto result = IComposable()
+		 *		.WithComponent<FMyComponent>().With(TAlias<
+		 *			FMyComponentBase,
+		 *			IMyComponentInterface
+		 *		>)
+		 *	;
+		 *	@endcode
+		 *	
+		 *	This overload is available for composable classes which also inherit from `TSharedFromThis`.
+		 *
+		 *	@warning
+		 *	Calling this function before adding a component may result in a runtime crash!
+		 *	
+		 *	@tparam ValidAs
+		 *	The list of other types the last added component is convertible to and may be used to get the last component
+		 *	among others which may list the same aliases.
+		 *	
+		 *	@tparam Self  Deducing this
+		 *	@param  self  Deducing this
+		 *
+		 *	@return
+		 *	If the composable class also inherits from `TSharedFromThis` return a shared ref.
+		 */
+		template <CSharedFromThis Self, typename... ValidAs>
+		auto With(this Self&& self, TAlias<ValidAs...>&&)
+		{
+			self.template AddAlias<ValidAs...>();
+			return self.SharedThis(&self);
+		}
+
+		/**
+		 *	@brief
+		 *	Add a list of types the last added component is convertible to and may be used to get the last component
+		 *	among others which may list the same aliases.
+		 *
+		 *	Usage:
+		 *	@code
+		 *	auto result = IComposable()
+		 *		.WithComponent<FMyComponent>().With(TAlias<
+		 *			FMyComponentBase,
+		 *			IMyComponentInterface
+		 *		>)
+		 *	;
+		 *	@endcode
+		 *	
+		 *	This overload is available for composable classes which are not explicitly meant to be used with shared pointers.
+		 *
+		 *	@warning
+		 *	Calling this function before adding a component may result in a runtime crash!
+		 *	
+		 *	@tparam ValidAs
+		 *	The list of other types the last added component is convertible to and may be used to get the last component
+		 *	among others which may list the same aliases.
+		 *	
+		 *	@tparam Self  Deducing this
+		 *	@param  self  Deducing this
+		 *
+		 *	@return
+		 *	Perfect-forwarded self.
+		 */
+		template <typename Self, typename... ValidAs>
+		requires (!CSharedFromThis<Self>)
+		decltype(auto) With(this Self&& self, TAlias<ValidAs...>&&)
+		{
+			self.template AddAlias<ValidAs...>();
+			return Forward<Self>(self);
+		}
+
+		/**
+		 *	@brief
+		 *	Get all components added matching~ or aliased by the given type.
+		 *	
+		 *	@tparam T  Desired component type.
+		 *	
+		 *	@return
+		 *	A range-view containing all the matched components. Components are provided as pointers to ensure they're
+		 *	not copied even under intricate object plumbing situations, but invalid pointers are never returned.
+		 *	(as long as the composable class is alive of course)
+		 */
+		template <typename T>
+		ranges::any_view<T*> GetComponents() const
+		{
+			namespace rv = ranges::views;
+			return GetComponentsPrivate(TTypeHash<T>)
+				| rv::transform([](FAny* component) { return component->TryGet<T>(); })
+				| FilterValid();
+		}
+
+		/**
+		 *	@brief
+		 *	Get the first component matching~ or aliased by the given type.
+		 *
+		 *	The order of components are non-deterministic so this method only make sense when it is trivial that only
+		 *	one component will be available for that particular type.
+		 *	
+		 *	@tparam T  Desired component type.
+		 *	
+		 *	@return
+		 *	A pointer to the component if one at least exists, nullptr otherwise.
+		 */
 		template <typename T>
 		const T* TryGetComponent() const
 		{
-			if (const FAny* component = TryGetComponentPrivate<T>())
-				return component->TryGet<T>();
-			return nullptr;
+			return GetComponents<T>() | FirstOrDefault();
 		}
 
+		/**
+		 *	@brief
+		 *	Get the first component matching~ or aliased by the given type.
+		 *
+		 *	The order of components are non-deterministic so this method only make sense when it is trivial that only
+		 *	one component will be available for that particular type.
+		 *	
+		 *	@tparam T  Desired component type.
+		 *	
+		 *	@return
+		 *	A pointer to the component if one at least exists, nullptr otherwise.
+		 */
 		template <typename T>
 		T* TryGetComponent()
 		{
-			if (FAny* component = TryGetComponentPrivate<T>())
-				return component->TryGet<T>();
-			return nullptr;
+			return GetComponents<T>() | FirstOrDefault();
 		}
 		
+		/**
+		 *	@brief
+		 *	Get the first component matching~ or aliased by the given type.
+		 *
+		 *	The order of components are non-deterministic so this method only make sense when it is trivial that only
+		 *	one component will be available for that particular type.
+		 *
+		 *	@warning
+		 *	If there may be the slightest doubt that the given component may not exist on this composable class, use
+		 *	`TryGetComponent` instead as this function can crash at runtime.
+		 *	
+		 *	@tparam T  Desired component type.
+		 *	
+		 *	@return
+		 *	A reference to the desired component. It is a runtime crash if the component doesn't exist.
+		 */
 		template <typename T>
 		T const& GetComponent() const
 		{
@@ -157,6 +611,22 @@ namespace Mcro::Composition
 			return *result;
 		}
 		
+		/**
+		 *	@brief
+		 *	Get the first component matching~ or aliased by the given type.
+		 *
+		 *	The order of components are non-deterministic so this method only make sense when it is trivial that only
+		 *	one component will be available for that particular type.
+		 *
+		 *	@warning
+		 *	If there may be the slightest doubt that the given component may not exist on this composable class, use
+		 *	`TryGetComponent` instead as this function can crash at runtime.
+		 *	
+		 *	@tparam T  Desired component type.
+		 *	
+		 *	@return
+		 *	A reference to the desired component. It is a runtime crash if the component doesn't exist.
+		 */
 		template <typename T>
 		T& GetComponent()
 		{

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
@@ -144,6 +144,9 @@ namespace Mcro::Composition
 	 *		                                   // at OnComponentRegistered(FExpectedParent& to)
 	 *	;
 	 *	@endcode
+	 *
+	 *	Explicit components can support multiple composable classes via function overloading or templating (with deduced
+	 *	type parameters).
 	 *	
 	 *	@todo
 	 *	C++ 26 has promising proposal for static value-based reflection, which can gather metadata from classes
@@ -285,7 +288,7 @@ namespace Mcro::Composition
 		auto WithComponent(this Self&& self, MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
 			Forward<Self>(self).template AddComponent<MainType, Self>(newComponent, facilities);
-			return self.SharedThis(&self);
+			return StaticCastSharedRef<std::decay_t<Self>>(self.AsShared());
 		}
 		
 		/**
@@ -309,7 +312,7 @@ namespace Mcro::Composition
 		auto WithComponent(this Self&& self, TAnyTypeFacilities<MainType> const& facilities = {})
 		{
 			Forward<Self>(self).template AddComponent<MainType, Self>(facilities);
-			return self.SharedThis(&self);
+			return StaticCastSharedRef<std::decay_t<Self>>(self.AsShared());
 		}
 
 		/**
@@ -403,7 +406,7 @@ namespace Mcro::Composition
 		auto WithAlias(this Self&& self)
 		{
 			Forward<Self>(self).template AddAlias<ValidAs>();
-			return self.SharedThis(&self);
+			return StaticCastSharedRef<std::decay_t<Self>>(self.AsShared());
 		}
 
 		/**
@@ -482,7 +485,7 @@ namespace Mcro::Composition
 		auto With(this Self&& self, TAlias<ValidAs...>&&)
 		{
 			Forward<Self>(self).template AddAlias<ValidAs...>();
-			return self.SharedThis(&self);
+			return StaticCastSharedRef<std::decay_t<Self>>(self.AsShared());
 		}
 
 		/**

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Composition.h
@@ -1,0 +1,168 @@
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  This Source Code is subject to the terms of the Mozilla Public License, v2.0.
+ *  If a copy of the MPL was not distributed with this file You can obtain one at
+ *  https://mozilla.org/MPL/2.0/
+ *  
+ *  @author David Mórász
+ *  @date 2025
+ */
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Mcro/Any.h"
+#include "Mcro/TextMacros.h"
+#include "Mcro/AssertMacros.h"
+
+/** @brief Namespace containing utilities and base classes for type composition */
+namespace Mcro::Composition
+{
+	using namespace Mcro::Any;
+
+	/**
+	 *	@brief  
+	 */
+	class IHaveComponents
+	{
+		mutable TMap<uint64, TVariant<FAny, uint64>> Components;
+
+		template <typename T>
+		bool HasExactComponent() const
+		{
+			return Components.Contains(TTypeHash<T>) && Components[TTypeHash<T>].template IsType<FAny>();
+		}
+
+		template <typename T>
+		bool HasComponentAliasUnchecked() const
+		{
+			return Components.Contains(TTypeHash<T>) && Components[TTypeHash<T>].template IsType<uint64>();
+		}
+
+		template <typename T>
+		uint64 GetRealComponentHash() const
+		{
+			return HasExactComponent<T>()
+				? TTypeHash<T>
+				: HasComponentAliasUnchecked<T>()
+				? Components[TTypeHash<T>].template Get<uint64>()
+				: 0;
+		}
+
+		template <typename T>
+		bool HasComponentAlias() const
+		{
+			if (HasComponentAliasUnchecked<T>())
+			{
+				uint64 realComponent = GetRealComponentHash<T>();
+				if (Components.Contains(realComponent)) return true;
+				Components.Remove(TTypeHash<T>);
+			}
+			return false;
+		}
+
+		template <typename T>
+		const FAny* TryGetComponentPrivate() const
+		{
+			uint64 realComponent = GetRealComponentHash<T>();
+			if (const auto* variant = Components.Find(realComponent))
+				return &variant->Get<FAny>();
+			return nullptr;
+		}
+
+		template <typename T>
+		FAny* TryGetComponentPrivate()
+		{
+			uint64 realComponent = GetRealComponentHash<T>();
+			if (auto* variant = Components.Find(realComponent))
+				return &variant->Get<FAny>();
+			return nullptr;
+		}
+
+		template <typename MainType, typename ValidAs>
+		void AddComponentAlias()
+		{
+			if (!ensureMsgf(
+				!HasExactComponent<ValidAs>(),
+				TEXT_"%s won't be used with %s because a real component already exists under that type.",
+				*TTypeString<MainType>(),
+				*TTypeString<ValidAs>()
+			)) return;
+			
+			if (!ensureMsgf(
+				!HasComponentAlias<ValidAs>(),
+				TEXT_"%s won't be used with %s because another component %s already uses it as an alias.",
+				*TTypeString<MainType>(),
+				*TTypeString<ValidAs>(),
+				*TryGetComponentPrivate<ValidAs>()->GetType().ToStringCopy()
+			)) return;
+
+			Components.Add(TTypeHash<ValidAs>, {TInPlaceType<uint64>(), TTypeHash<MainType>});
+		}
+
+	public:
+		template <typename MainType, typename... ValidAs>
+		MainType& AddComponent(MainType* newComponent, TAnyTypeFacilities<MainType> const& facilities = {})
+		{
+			ASSERT_CRASH(newComponent);
+			ASSERT_CRASH(!HasExactComponent<MainType>(), ->WithMessageF(
+				TEXT_"{0} cannot be added because another component already exists under that type.",
+				TTypeName<MainType>
+			));
+			ASSERT_CRASH(!HasComponentAlias<MainType>(), ->WithMessageF(
+				TEXT_"{0} cannot be added because another component {1} already uses {0} as an alias.",
+				TTypeName<MainType>,
+				TryGetComponentPrivate<MainType>()->GetType()
+			));
+			
+			Components.Add(TTypeHash<MainType>, {TInPlaceType<FAny>(), FAny(newComponent, facilities).ValidAs<ValidAs...>()});
+			(AddComponentAlias<MainType, ValidAs>(), ...);
+			return *newComponent;
+		}
+		
+		template <CDefaultInitializable MainType, typename... ValidAs>
+		MainType& AddComponent(TAnyTypeFacilities<MainType> const& facilities = {})
+		{
+			return AddComponent<MainType, ValidAs...>(new MainType(), facilities);
+		}
+		
+		template <CDefaultInitializable MainType, typename... ValidAs>
+		MainType& GetOrAddComponent(TAnyTypeFacilities<MainType> const& facilities = {})
+		{
+			return AddComponent<MainType, ValidAs...>(new MainType(), facilities);
+		}
+
+		template <typename T>
+		const T* TryGetComponent() const
+		{
+			if (const FAny* component = TryGetComponentPrivate<T>())
+				return component->TryGet<T>();
+			return nullptr;
+		}
+
+		template <typename T>
+		T* TryGetComponent()
+		{
+			if (FAny* component = TryGetComponentPrivate<T>())
+				return component->TryGet<T>();
+			return nullptr;
+		}
+		
+		template <typename T>
+		T const& GetComponent() const
+		{
+			const T* result = TryGetComponent<T>();
+			ASSERT_CRASH(result, ->WithMessageF(TEXT_"Component {0} was unavailable.", TTypeName<T>));
+			return *result;
+		}
+		
+		template <typename T>
+		T& GetComponent()
+		{
+			T* result = TryGetComponent<T>();
+			ASSERT_CRASH(result, ->WithMessageF(TEXT_"Component {0} was unavailable.", TTypeName<T>));
+			return *result;
+		}
+	};
+}

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Concepts.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Concepts.h
@@ -97,10 +97,10 @@ namespace Mcro::Concepts
 	template<typename A, typename B>
 	concept CCoreHalfEqualityComparable =
 		requires(const std::remove_reference_t<A>& a, const std::remove_reference_t<B>& b)
-	{
-		{ a == b } -> CBooleanTestable;
-		{ a != b } -> CBooleanTestable;
-	}
+		{
+			{ a == b } -> CBooleanTestable;
+			{ a != b } -> CBooleanTestable;
+		}
 	;
 
 	template<typename A, typename B>
@@ -323,15 +323,13 @@ namespace Mcro::Concepts
 	 *	class MyClass
 	 *	{
 	 *		int myMember;
-	 *	}
+	 *	};
 	 *	
-	 *	CMemberPointerOf<MyClass, &MyClass::myMember> // --> true;
+	 *	CMemberPointerOf<MyClass, &MyClass::myMember>; // --> true;
 	 *	
-	 *	class MyOtherClass
-	 *	{
-	 *	}
+	 *	class MyOtherClass {};
 	 *	
-	 *	CMemberPointerOf<MyOtherClass, &MyClass::myMember> // --> false;
+	 *	CMemberPointerOf<MyOtherClass, &MyClass::myMember>; // --> false;
 	 *	@endcode
 	 */
 	template <typename OwnerObject, typename MemberPointerType>

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.h
@@ -1,40 +1,41 @@
-﻿/*
-BSD 2-Clause License
-
-constexpr-xxh3 - C++20 constexpr implementation of the XXH3 64-bit variant of xxHash
-Copyright (c) 2021-2023, chys <admin@chys.info> <chys87@github>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
-/*
-This file uses code from Yann Collet's xxHash implementation.
-Original xxHash copyright notice:
-
-xxHash - Extremely Fast Hash algorithm
-Header File
-Copyright (C) 2012-2020 Yann Collet
-*/
+﻿/** @noop License Comment
+ *  @file
+ *  @copyright
+ *  BSD 2-Clause License
+ *  @copyright
+ *  constexpr-xxh3 - C++20 constexpr implementation of the XXH3 64-bit variant of xxHash
+ *  Copyright (c) 2021-2023, chys <admin@chys.info> <chys87@github>
+ *  All rights reserved.
+ *  @copyright
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *  @copyright
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *  @copyright
+ *  This file uses code from Yann Collet's xxHash implementation.
+ *  Original xxHash copyright notice:
+ *  @copyright
+ *  xxHash - Extremely Fast Hash algorithm
+ *  Header File
+ *  Copyright (C) 2012-2020 Yann Collet
+ *  
+ *  @author Chys <admin@chys.info> <chys87@github>; Yann Collet
+ *  @date 2025
+ */
 
 #pragma once
 

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.h
@@ -1,0 +1,355 @@
+﻿/*
+BSD 2-Clause License
+
+constexpr-xxh3 - C++20 constexpr implementation of the XXH3 64-bit variant of xxHash
+Copyright (c) 2021-2023, chys <admin@chys.info> <chys87@github>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+This file uses code from Yann Collet's xxHash implementation.
+Original xxHash copyright notice:
+
+xxHash - Extremely Fast Hash algorithm
+Header File
+Copyright (C) 2012-2020 Yann Collet
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>  // for std::data, std::size
+#include <type_traits>
+#include <utility>
+
+namespace constexpr_xxh3 {
+
+template <typename T>
+concept ByteType = (std::is_integral_v<T> && sizeof(T) == 1)
+#if defined __cpp_lib_byte && __cpp_lib_byte >= 201603
+                   || std::is_same_v<T, std::byte>
+#endif
+    ;
+
+template <typename T>
+concept BytePtrType = requires (T ptr) {
+  requires std::is_pointer_v<T>;
+  requires ByteType<std::remove_cvref_t<decltype(*ptr)>>;
+};
+
+template <typename T>
+concept BytesType = requires (const T& bytes) {
+  { std::data(bytes) };
+  requires BytePtrType<decltype(std::data(bytes))>;
+  // -> std::convertible_to is not supported widely enough
+  { static_cast<size_t>(std::size(bytes)) };
+};
+
+inline constexpr uint32_t swap32(uint32_t x) noexcept {
+  return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) |
+         ((x >> 8) & 0x0000ff00) | ((x >> 24) & 0x000000ff);
+}
+
+template <typename T>
+inline constexpr uint32_t readLE32(const T* ptr) noexcept {
+  return uint8_t(ptr[0]) | uint32_t(uint8_t(ptr[1])) << 8 |
+         uint32_t(uint8_t(ptr[2])) << 16 | uint32_t(uint8_t(ptr[3])) << 24;
+}
+
+inline constexpr uint64_t swap64(uint64_t x) noexcept {
+  return ((x << 56) & 0xff00000000000000ULL) |
+         ((x << 40) & 0x00ff000000000000ULL) |
+         ((x << 24) & 0x0000ff0000000000ULL) |
+         ((x << 8) & 0x000000ff00000000ULL) |
+         ((x >> 8) & 0x00000000ff000000ULL) |
+         ((x >> 24) & 0x0000000000ff0000ULL) |
+         ((x >> 40) & 0x000000000000ff00ULL) |
+         ((x >> 56) & 0x00000000000000ffULL);
+}
+
+template <typename T>
+inline constexpr uint64_t readLE64(const T* ptr) noexcept {
+  return readLE32(ptr) | uint64_t(readLE32(ptr + 4)) << 32;
+}
+
+inline constexpr void writeLE64(uint8_t* dst, uint64_t v) noexcept {
+  for (int i = 0; i < 8; ++i) dst[i] = uint8_t(v >> (i * 8));
+}
+
+inline constexpr uint32_t PRIME32_1 = 0x9E3779B1U;
+inline constexpr uint32_t PRIME32_2 = 0x85EBCA77U;
+inline constexpr uint32_t PRIME32_3 = 0xC2B2AE3DU;
+
+inline constexpr uint64_t PRIME64_1 = 0x9E3779B185EBCA87ULL;
+inline constexpr uint64_t PRIME64_2 = 0xC2B2AE3D27D4EB4FULL;
+inline constexpr uint64_t PRIME64_3 = 0x165667B19E3779F9ULL;
+inline constexpr uint64_t PRIME64_4 = 0x85EBCA77C2B2AE63ULL;
+inline constexpr uint64_t PRIME64_5 = 0x27D4EB2F165667C5ULL;
+
+inline constexpr size_t SECRET_DEFAULT_SIZE = 192;
+inline constexpr size_t SECRET_SIZE_MIN = 136;
+
+inline constexpr uint8_t kSecret[SECRET_DEFAULT_SIZE]{
+    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c,
+    0xf7, 0x21, 0xad, 0x1c, 0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb,
+    0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f, 0xcb, 0x79, 0xe6, 0x4e,
+    0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
+    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6,
+    0x81, 0x3a, 0x26, 0x4c, 0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb,
+    0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3, 0x71, 0x64, 0x48, 0x97,
+    0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
+    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7,
+    0xc7, 0x0b, 0x4f, 0x1d, 0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31,
+    0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64, 0xea, 0xc5, 0xac, 0x83,
+    0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
+    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26,
+    0x29, 0xd4, 0x68, 0x9e, 0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc,
+    0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce, 0x45, 0xcb, 0x3a, 0x8f,
+    0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
+};
+
+inline constexpr std::pair<uint64_t, uint64_t> mult64to128(
+    uint64_t lhs, uint64_t rhs) noexcept {
+  uint64_t lo_lo = uint64_t(uint32_t(lhs)) * uint32_t(rhs);
+  uint64_t hi_lo = (lhs >> 32) * uint32_t(rhs);
+  uint64_t lo_hi = uint32_t(lhs) * (rhs >> 32);
+  uint64_t hi_hi = (lhs >> 32) * (rhs >> 32);
+  uint64_t cross = (lo_lo >> 32) + uint32_t(hi_lo) + lo_hi;
+  uint64_t upper = (hi_lo >> 32) + (cross >> 32) + hi_hi;
+  uint64_t lower = (cross << 32) | uint32_t(lo_lo);
+  return {lower, upper};
+}
+
+inline constexpr uint64_t mul128_fold64(uint64_t lhs, uint64_t rhs) noexcept {
+#if defined __GNUC__ && __WORDSIZE >= 64
+  // It appears both GCC and Clang support evaluating __int128 as constexpr
+  auto product = static_cast<unsigned __int128>(lhs) * rhs;
+  return uint64_t(product >> 64) ^ uint64_t(product);
+#else
+  auto product = mult64to128(lhs, rhs);
+  return product.first ^ product.second;
+#endif
+}
+
+inline constexpr uint64_t XXH64_avalanche(uint64_t h) noexcept {
+  h = (h ^ (h >> 33)) * PRIME64_2;
+  h = (h ^ (h >> 29)) * PRIME64_3;
+  return h ^ (h >> 32);
+}
+
+inline constexpr uint64_t XXH3_avalanche(uint64_t h) noexcept {
+  h = (h ^ (h >> 37)) * 0x165667919E3779F9ULL;
+  return h ^ (h >> 32);
+}
+
+inline constexpr uint64_t rrmxmx(uint64_t h, uint64_t len) noexcept {
+  h ^= ((h << 49) | (h >> 15)) ^ ((h << 24) | (h >> 40));
+  h *= 0x9FB21C651E98DF25ULL;
+  h ^= (h >> 35) + len;
+  h *= 0x9FB21C651E98DF25ULL;
+  return h ^ (h >> 28);
+}
+
+template <typename T, typename S>
+constexpr uint64_t mix16B(const T* input, const S* secret,
+                          uint64_t seed) noexcept {
+  return mul128_fold64(readLE64(input) ^ (readLE64(secret) + seed),
+                       readLE64(input + 8) ^ (readLE64(secret + 8) - seed));
+}
+
+inline constexpr size_t STRIPE_LEN = 64;
+inline constexpr size_t SECRET_CONSUME_RATE = 8;
+inline constexpr size_t ACC_NB = STRIPE_LEN / sizeof(uint64_t);
+
+template <typename T, typename S>
+constexpr void accumulate_512(uint64_t* acc, const T* input,
+                              const S* secret) noexcept {
+  for (size_t i = 0; i < ACC_NB; i++) {
+    uint64_t data_val = readLE64(input + 8 * i);
+    uint64_t data_key = data_val ^ readLE64(secret + i * 8);
+    acc[i ^ 1] += data_val;
+    acc[i] += uint32_t(data_key) * (data_key >> 32);
+  }
+}
+
+template <typename T, typename S>
+constexpr uint64_t hashLong_64b_internal(const T* input, size_t len,
+                                         const S* secret,
+                                         size_t secretSize) noexcept {
+  uint64_t acc[ACC_NB]{PRIME32_3, PRIME64_1, PRIME64_2, PRIME64_3,
+                       PRIME64_4, PRIME32_2, PRIME64_5, PRIME32_1};
+  size_t nbStripesPerBlock = (secretSize - STRIPE_LEN) / SECRET_CONSUME_RATE;
+  size_t block_len = STRIPE_LEN * nbStripesPerBlock;
+  size_t nb_blocks = (len - 1) / block_len;
+
+  for (size_t n = 0; n < nb_blocks; n++) {
+    for (size_t i = 0; i < nbStripesPerBlock; i++)
+      accumulate_512(acc, input + n * block_len + i * STRIPE_LEN,
+                     secret + i * SECRET_CONSUME_RATE);
+    for (size_t i = 0; i < ACC_NB; i++)
+      acc[i] = (acc[i] ^ (acc[i] >> 47) ^
+                readLE64(secret + secretSize - STRIPE_LEN + 8 * i)) *
+               PRIME32_1;
+  }
+
+  size_t nbStripes = ((len - 1) - (block_len * nb_blocks)) / STRIPE_LEN;
+  for (size_t i = 0; i < nbStripes; i++)
+    accumulate_512(acc, input + nb_blocks * block_len + i * STRIPE_LEN,
+                   secret + i * SECRET_CONSUME_RATE);
+  accumulate_512(acc, input + len - STRIPE_LEN,
+                 secret + secretSize - STRIPE_LEN - 7);
+  uint64_t result = len * PRIME64_1;
+  for (size_t i = 0; i < 4; i++)
+    result +=
+        mul128_fold64(acc[2 * i] ^ readLE64(secret + 11 + 16 * i),
+                      acc[2 * i + 1] ^ readLE64(secret + 11 + 16 * i + 8));
+  return XXH3_avalanche(result);
+}
+
+template <typename T, typename S, typename HashLong>
+constexpr uint64_t XXH3_64bits_internal(const T* input, size_t len,
+                                        uint64_t seed, const S* secret,
+                                        size_t secretLen,
+                                        HashLong f_hashLong) noexcept {
+  if (len == 0) {
+    return XXH64_avalanche(seed ^
+                           (readLE64(secret + 56) ^ readLE64(secret + 64)));
+  } else if (len < 4) {
+    uint64_t keyed = ((uint32_t(uint8_t(input[0])) << 16) |
+                      (uint32_t(uint8_t(input[len >> 1])) << 24) |
+                      uint8_t(input[len - 1]) | (uint32_t(len) << 8)) ^
+                     ((readLE32(secret) ^ readLE32(secret + 4)) + seed);
+    return XXH64_avalanche(keyed);
+  } else if (len <= 8) {
+    uint64_t keyed =
+        (readLE32(input + len - 4) + (uint64_t(readLE32(input)) << 32)) ^
+        ((readLE64(secret + 8) ^ readLE64(secret + 16)) -
+         (seed ^ (uint64_t(swap32(uint32_t(seed))) << 32)));
+    return rrmxmx(keyed, len);
+  } else if (len <= 16) {
+    uint64_t input_lo =
+        readLE64(input) ^
+        ((readLE64(secret + 24) ^ readLE64(secret + 32)) + seed);
+    uint64_t input_hi =
+        readLE64(input + len - 8) ^
+        ((readLE64(secret + 40) ^ readLE64(secret + 48)) - seed);
+    uint64_t acc =
+        len + swap64(input_lo) + input_hi + mul128_fold64(input_lo, input_hi);
+    return XXH3_avalanche(acc);
+  } else if (len <= 128) {
+    uint64_t acc = len * PRIME64_1;
+    size_t secret_off = 0;
+    for (size_t i = 0, j = len; j > i; i += 16, j -= 16) {
+      acc += mix16B(input + i, secret + secret_off, seed);
+      acc += mix16B(input + j - 16, secret + secret_off + 16, seed);
+      secret_off += 32;
+    }
+    return XXH3_avalanche(acc);
+  } else if (len <= 240) {
+    uint64_t acc = len * PRIME64_1;
+    for (size_t i = 0; i < 128; i += 16)
+      acc += mix16B(input + i, secret + i, seed);
+    acc = XXH3_avalanche(acc);
+    for (size_t i = 128; i < len / 16 * 16; i += 16)
+      acc += mix16B(input + i, secret + (i - 128) + 3, seed);
+    acc += mix16B(input + len - 16, secret + SECRET_SIZE_MIN - 17, seed);
+    return XXH3_avalanche(acc);
+  } else {
+    return f_hashLong(input, len, seed, secret, secretLen);
+  }
+}
+
+template <BytesType Bytes>
+constexpr size_t bytes_size(const Bytes& bytes) noexcept {
+  return std::size(bytes);
+}
+
+template <ByteType T, size_t N>
+constexpr size_t bytes_size(T (&)[N]) noexcept {
+  return (N ? N - 1 : 0);
+}
+
+/// Basic interfaces
+
+template <ByteType T>
+consteval uint64_t XXH3_64bits_const(const T* input, size_t len) noexcept {
+  return XXH3_64bits_internal(
+      input, len, 0, kSecret, sizeof(kSecret),
+      [](const T* input, size_t len, uint64_t, const void*,
+         size_t) constexpr noexcept {
+        return hashLong_64b_internal(input, len, kSecret, sizeof(kSecret));
+      });
+}
+
+template <ByteType T, ByteType S>
+consteval uint64_t XXH3_64bits_withSecret_const(const T* input, size_t len,
+                                                const S* secret,
+                                                size_t secretSize) noexcept {
+  return XXH3_64bits_internal(
+      input, len, 0, secret, secretSize,
+      [](const T* input, size_t len, uint64_t, const S* secret,
+         size_t secretLen) constexpr noexcept {
+        return hashLong_64b_internal(input, len, secret, secretLen);
+      });
+}
+
+template <ByteType T>
+consteval uint64_t XXH3_64bits_withSeed_const(const T* input, size_t len,
+                                              uint64_t seed) noexcept {
+  if (seed == 0) return XXH3_64bits_const(input, len);
+  return XXH3_64bits_internal(
+      input, len, seed, kSecret, sizeof(kSecret),
+      [](const T* input, size_t len, uint64_t seed, const void*,
+         size_t) constexpr noexcept {
+        uint8_t secret[SECRET_DEFAULT_SIZE];
+        for (size_t i = 0; i < SECRET_DEFAULT_SIZE; i += 16) {
+          writeLE64(secret + i, readLE64(kSecret + i) + seed);
+          writeLE64(secret + i + 8, readLE64(kSecret + i + 8) - seed);
+        }
+        return hashLong_64b_internal(input, len, secret, sizeof(secret));
+      });
+}
+
+/// Convenient interfaces
+
+template <BytesType Bytes>
+consteval uint64_t XXH3_64bits_const(const Bytes& input) noexcept {
+  return XXH3_64bits_const(std::data(input), bytes_size(input));
+}
+
+template <BytesType Bytes, BytesType Secret>
+consteval uint64_t XXH3_64bits_withSecret_const(const Bytes& input,
+                                                const Secret& secret) noexcept {
+  return XXH3_64bits_withSecret_const(std::data(input), bytes_size(input),
+                                      std::data(secret), bytes_size(secret));
+}
+
+template <BytesType Bytes>
+consteval uint64_t XXH3_64bits_withSeed_const(const Bytes& input,
+                                              uint64_t seed) noexcept {
+  return XXH3_64bits_withSeed_const(std::data(input), bytes_size(input), seed);
+}
+
+}  // namespace constexpr_xxh3

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.tp.yml
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.tp.yml
@@ -2,7 +2,7 @@
 source: https://github.com/chys87/constexpr-xxh3
 project: https://github.com/chys87/constexpr-xxh3
 authors:
-    - Chys (ttps://chys.info)
+    - Chys (https://chys.info)
 license: BSD 2-Clause License (https://github.com/chys87/constexpr-xxh3/blob/main/LICENSE)
 reasoning: |
     This allows us to have almost free runtime exact type checking.

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.tp.yml
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/ConstexprXXH3.tp.yml
@@ -1,0 +1,8 @@
+﻿name: constexpr-xxh3
+source: https://github.com/chys87/constexpr-xxh3
+project: https://github.com/chys87/constexpr-xxh3
+authors:
+    - Chys (ttps://chys.info)
+license: BSD 2-Clause License (https://github.com/chys87/constexpr-xxh3/blob/main/LICENSE)
+reasoning: |
+    This allows us to have almost free runtime exact type checking.

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Error.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Error.h
@@ -200,13 +200,13 @@ namespace Mcro::Error
 		 *	@tparam  Self     Deducing this
 		 *	@param   self     Deduced this (not present in calling arguments)
 		 *	@param   input    the message format
-		 *	@param   fmtArgs  format arguments
+		 *	@param   fmtArgs  ordered format arguments
 		 *	@return  Self for further fluent API setup
 		 */
-		template <typename Self, typename... FormatArgs>
+		template <typename Self, CStringFormatArgument... FormatArgs>
 		SelfRef<Self> WithMessageF(this Self&& self, const TCHAR* input, FormatArgs&&... fmtArgs)
 		{
-			self.Message = DynamicPrintf(input, Forward<FormatArgs>(fmtArgs)...);
+			self.Message = FString::Format(input, OrderedArguments(Forward<FormatArgs>(fmtArgs)...));
 			return self.SharedThis(&self);
 		}
 
@@ -222,7 +222,7 @@ namespace Mcro::Error
 		template <typename Self, typename... FormatArgs>
 		SelfRef<Self> WithMessageFC(this Self&& self, bool condition, const TCHAR* input, FormatArgs&&... fmtArgs)
 		{
-			if (condition) self.Message = DynamicPrintf(input, Forward<FormatArgs>(fmtArgs)...);
+			if (condition) self.Message = FString::Format(input, OrderedArguments(Forward<FormatArgs>(fmtArgs)...));
 			return self.SharedThis(&self);
 		}
 		
@@ -291,13 +291,13 @@ namespace Mcro::Error
 		 *	@tparam  Self     Deducing this
 		 *	@param   self     Deduced this (not present in calling arguments)
 		 *	@param   input    the details text
-		 *	@param   fmtArgs  format arguments
+		 *	@param   fmtArgs  ordered format arguments
 		 *	@return  Self for further fluent API setup
 		 */
-		template <typename Self, typename... FormatArgs>
+		template <typename Self, CStringFormatArgument... FormatArgs>
 		SelfRef<Self> WithDetailsF(this Self&& self, const TCHAR* input, FormatArgs&&... fmtArgs)
 		{
-			self.Details = DynamicPrintf(input, Forward<FormatArgs>(fmtArgs)...);
+			self.Details = FString::Format(input, OrderedArguments(Forward<FormatArgs>(fmtArgs)...));
 			return self.SharedThis(&self);
 		}
 
@@ -310,13 +310,13 @@ namespace Mcro::Error
 		 *	@param   self       Deduced this (not present in calling arguments)
 		 *	@param   input      the details text
 		 *	@param   condition  Only add details when this condition is satisfied
-		 *	@param   fmtArgs    format arguments
+		 *	@param   fmtArgs    ordered format arguments
 		 *	@return  Self for further fluent API setup
 		 */
-		template <typename Self, typename... FormatArgs>
+		template <typename Self, CStringFormatArgument... FormatArgs>
 		SelfRef<Self> WithDetailsFC(this Self&& self, bool condition, const TCHAR* input, FormatArgs&&... fmtArgs)
 		{
-			if (condition) self.Details = DynamicPrintf(input, Forward<FormatArgs>(fmtArgs)...);
+			if (condition) self.Details = FString::Format(input, OrderedArguments(Forward<FormatArgs>(fmtArgs)...));
 			return self.SharedThis(&self);
 		}
 
@@ -435,13 +435,13 @@ namespace Mcro::Error
 		 *	@tparam  Self     Deducing this
 		 *	@param   name     Name of the extra text block
 		 *	@param   text     Value of the extra text block
-		 *	@param   fmtArgs  format arguments
+		 *	@param   fmtArgs  ordered format arguments
 		 *	@return  Self for further fluent API setup
 		 */
-		template <typename Self, typename... FormatArgs>
+		template <typename Self, CStringFormatArgument... FormatArgs>
 		SelfRef<Self> WithAppendixF(this Self&& self, const FString& name, const TCHAR* text, FormatArgs&&... fmtArgs)
 		{
-			self.AddAppendix(name, DynamicPrintf(text, Forward<FormatArgs>(fmtArgs)...));
+			self.AddAppendix(name, FString::Format(text, OrderedArguments(Forward<FormatArgs>(fmtArgs)...)));
 			return self.SharedThis(&self);
 		}
 
@@ -450,15 +450,15 @@ namespace Mcro::Error
 		 *	@tparam  Self       Deducing this
 		 *	@param   name       Name of the extra text block
 		 *	@param   text       Value of the extra text block
-		 *	@param   fmtArgs    format arguments
+		 *	@param   fmtArgs    ordered format arguments
 		 *	@param   condition  Only add inner error when this condition is satisfied
 		 *	@return  Self for further fluent API setup
 		 */
-		template <typename Self, typename... FormatArgs>
+		template <typename Self, CStringFormatArgument... FormatArgs>
 		SelfRef<Self> WithAppendixFC(this Self&& self, bool condition, const FString& name, const TCHAR* text, FormatArgs&&... fmtArgs)
 		{
 			if (condition)
-				self.AddAppendix(name, DynamicPrintf(text, Forward<FormatArgs>(fmtArgs)...));
+				self.AddAppendix(name, FString::Format(text, OrderedArguments(Forward<FormatArgs>(fmtArgs)...)));
 			return self.SharedThis(&self);
 		}
 
@@ -573,8 +573,8 @@ namespace Mcro::Error
 		requires (!CDefaultInitializable<T>)
 		TMaybe() : Error(IError::Make(new FUnavailable())
 			->WithMessageF(
-				TEXT_"TMaybe has been default initialized, but a Value of %s cannot be default initialized",
-				*TTypeString<T>()
+				TEXT_"TMaybe has been default initialized, but a Value of {0} cannot be default initialized",
+				TTypeName<T>
 			)
 		) {}
 

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Range/Views.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Range/Views.h
@@ -64,16 +64,37 @@ namespace Mcro::Range
 		CRangeMember Input,
 		typename Value = TRangeElementType<Input>
 	>
-	decltype(auto) First(Input&& range, Value&& def = {})
+	decltype(auto) First(Input&& range, Value&& def)
 	{
 		return IsEmpty(range) ? def : *range.begin();
 	}
 
 	/** @brief Get's the first element of a range or return a provided default value. Same as `*r.begin()` but safer. */
-	template <typename Value>
-	auto First(Value&& def = {})
+	FORCEINLINE auto First(auto&& def)
 	{
 		return ranges::make_pipeable([&](auto&& left){ return First(left, def); });
+	}
+
+	/**
+	 *	@brief
+	 *	Get's the first element of a range or return the default value for the element type. Same as `*r.begin()` but safer.
+	 */
+	template <
+		CRangeMember Input,
+		typename Value = TRangeElementType<Input>
+	>
+	decltype(auto) FirstOrDefault(Input&& range)
+	{
+		return IsEmpty(range) ? Value{} : *range.begin();
+	}
+
+	/**
+	 *	@brief
+	 *	Get's the first element of a range or return the default value for the element type. Same as `*r.begin()` but safer.
+	 */
+	FORCEINLINE auto FirstOrDefault()
+	{
+		return ranges::make_pipeable([&](auto&& left){ return FirstOrDefault(left); });
 	}
 
 	/**

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Rendering/Textures.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Rendering/Textures.h
@@ -76,7 +76,7 @@ namespace Mcro::Rendering::Textures
 		default:
 			{
 				ASSERT_QUIT(false, RTF_R8,
-					->WithMessageF(TEXT_"Unhandled ETextureRenderTargetFormat entry %s", GetPixelFormatString(from))
+					->WithMessageF(TEXT_"Unhandled ETextureRenderTargetFormat entry {0}", GetPixelFormatString(from))
 				)
 				return RTF_R8;
 			};
@@ -106,7 +106,7 @@ namespace Mcro::Rendering::Textures
 			{
 				auto enumName = UEnum::GetValueAsString(from);
 				ASSERT_QUIT(false, PF_Unknown,
-					->WithMessageF(TEXT_"Unhandled ETextureRenderTargetFormat entry %s", *enumName)
+					->WithMessageF(TEXT_"Unhandled ETextureRenderTargetFormat entry {0}", enumName)
 				);
 				return PF_Unknown;
 			}

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Subsystems.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Subsystems.h
@@ -166,7 +166,7 @@ namespace Mcro::Subsystems
 			T* result = Get<T>(args...);
 			
 			ASSERT_CRASH(result,
-				->WithMessageF(TEXT_"Couldn't find required subsystem %s", *TTypeString<T>())
+				->WithMessageF(TEXT_"Couldn't find required subsystem {0}", TTypeName<T>)
 			)
 			
 			return *result;

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Templates.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Templates.h
@@ -43,6 +43,12 @@ namespace Mcro::Templates
     
 		template <typename... Params>
 		static constexpr bool Match<Template<Params...>> = true;
+		
+		template <typename T>
+		static constexpr size_t ParameterCount = 0;
+    
+		template <typename... Params>
+		static constexpr size_t ParameterCount<Template<Params...>> = sizeof...(Params);
 
 		template <typename T>
 		struct Parameters
@@ -55,6 +61,24 @@ namespace Mcro::Templates
 		{
 			using Type = TTuple<Params...>;
 		};
+
+		template <typename T>
+		struct ParametersDecay
+		{
+			using Type = TTuple<>;
+		};
+
+		template <typename... Params>
+		struct ParametersDecay<Template<Params...>>
+		{
+			using Type = TTuple<std::decay_t<Params>...>;
+		};
+
+		template <typename Instance, int I>
+		using Param = typename TTupleElement<I, typename Parameters<Instance>::Type>::Type;
+
+		template <typename Instance, int I>
+		using ParamDecay = typename TTupleElement<I, typename ParametersDecay<Instance>::Type>::Type;
 	};
 	
 	/**
@@ -65,8 +89,41 @@ namespace Mcro::Templates
 	 *	considered seriously, template traits only work with templates which only have type-parameters. Non-type
 	 *	parameters even when a default is specified for them will result in compile error.
 	 */
-	template <template <typename...> typename Template, typename T>
-	using TTemplate_Params = typename TTemplate<Template>::template Parameters<T>::Type;
+	template <template <typename...> typename Template, typename Instance>
+	using TTemplate_Params = typename TTemplate<Template>::template Parameters<Instance>::Type;
+	
+	/**
+	 *	@brief  Get decayed template type parameters as a tuple
+	 *
+	 *	@warning
+	 *	Until this proposal https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1985r0.pdf or equivalent is
+	 *	considered seriously, template traits only work with templates which only have type-parameters. Non-type
+	 *	parameters even when a default is specified for them will result in compile error.
+	 */
+	template <template <typename...> typename Template, typename Instance>
+	using TTemplate_ParamsDecay = typename TTemplate<Template>::template ParametersDecay<Instance>::Type;
+
+	/**
+	 *	@brief  Get a type parameter at a specified position of a templated instance. 
+	 *
+	 *	@warning
+	 *	Until this proposal https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1985r0.pdf or equivalent is
+	 *	considered seriously, template traits only work with templates which only have type-parameters. Non-type
+	 *	parameters even when a default is specified for them will result in compile error.
+	 */
+	template <template <typename...> typename Template, typename Instance, int I>
+	using TTemplate_Param = typename TTemplate<Template>::template Param<Instance, I>;
+
+	/**
+	 *	@brief  Get a decayed type parameter at a specified position of a templated instance. 
+	 *
+	 *	@warning
+	 *	Until this proposal https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1985r0.pdf or equivalent is
+	 *	considered seriously, template traits only work with templates which only have type-parameters. Non-type
+	 *	parameters even when a default is specified for them will result in compile error.
+	 */
+	template <template <typename...> typename Template, typename Instance, int I>
+	using TTemplate_ParamDecay = typename TTemplate<Template>::template ParamDecay<Instance, I>;
 
 	/**
 	 *	@brief  Check if given type is an instantiation of a given template (which only accepts type parameters)
@@ -76,8 +133,20 @@ namespace Mcro::Templates
 	 *	considered seriously, template traits only work with templates which only have type-parameters. Non-type
 	 *	parameters even when a default is specified for them will result in compile error.
 	 */
-	template <typename T, template <typename...> typename Template>
-	concept CIsTemplate = TTemplate<Template>::template Match<std::decay_t<T>>;
+	template <typename Instance, template <typename...> typename Template>
+	concept CIsTemplate = TTemplate<Template>::template Match<std::decay_t<Instance>>;
+
+	/**
+	 *	@brief
+	 *	Get the number of template type parameters from a specified templated instance (which only has type parameters) 
+	 *
+	 *	@warning
+	 *	Until this proposal https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1985r0.pdf or equivalent is
+	 *	considered seriously, template traits only work with templates which only have type-parameters. Non-type
+	 *	parameters even when a default is specified for them will result in compile error.
+	 */
+	template <template <typename...> typename Template, typename Instance>
+	inline constexpr size_t TTemplate_ParamCount =  TTemplate<Template>::template ParameterCount<Instance>;
 
 	/** @brief Tired of typing `const_cast<FMyLongUnwieldyTypeName>(...)`? use this instead */
 	template <CConstType T>

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Text.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Text.h
@@ -298,7 +298,7 @@ namespace Mcro::Text
 		{
 			ensureAlwaysMsgf(false,
 				TEXT("Given type %s couldn't be converted to a string. Typename is returned instead"),
-				TTypeName<T>.GetData()
+				*TTypeString<T>()
 			);
 			return TTypeName<T>;
 		}

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/TypeName.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/TypeName.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include "ConstexprXXH3.h"
 
 #include "CoreMinimal.h"
 #include "UnrealCtre.h"
@@ -92,6 +93,13 @@ consteval std::basic_string_view<TCHAR> GetCompileTimeTypeName()
 	return size ? output : std::basic_string_view<TCHAR>();
 }
 
+template <typename T>
+consteval uint64 GetCompileTimeTypeHash()
+{
+	std::string_view thisFunctionName { PRETTY_FUNC };
+	return constexpr_xxh3::XXH3_64bits_const(thisFunctionName);
+}
+
 /** Convert types to string */
 namespace Mcro::TypeName
 {
@@ -139,7 +147,11 @@ namespace Mcro::TypeName
 	 *	(e.g.: `TTypeName<class I>` of incomplete `I` might not be the same as `TTypeName<I>` somewhere
 	 *	else with `I` being fully defined)
 	 *	
-	 *	@tparam  T  The type to be named
+	*	@tparam  T  The type to be named
+	 *
+	 *	@warning
+	 *	Do not use exact type comparison with serialized data or network communication, as the actual value of the type
+	 *	is different between compilers. Only use this for runtime data. For such scenarios just use Unreal's own UObjects.
 	 */
 	template <typename T>
 	constexpr FStringView TTypeName = FStringView(
@@ -150,6 +162,10 @@ namespace Mcro::TypeName
 	/** @brief Same as `TTypeName` just stored as STL string made during compile time */
 	template <typename T>
 	constexpr std::basic_string_view<TCHAR> TTypeNameStd = GetCompileTimeTypeName<std::decay_t<T>>();
+
+	/** @brief Get a fixed `uint64` hash representation of the given type. Have similar caveats as `TTypeName` */
+	template <typename T>
+	constexpr uint64 TTypeHash = GetCompileTimeTypeHash<T>();
 
 	/**
 	 *	@brief

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/TypeName.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/TypeName.h
@@ -117,7 +117,7 @@ namespace Mcro::TypeName
 				GetCompileTimeTypeName<std::decay_t<T>>().data(),
 				GetCompileTimeTypeName<std::decay_t<T>>().size()
 			)
-			, Hash(GetCompileTimeTypeHash<T>())
+			, Hash(GetCompileTimeTypeHash<std::decay_t<T>>())
 		{}
 		
 		constexpr FType() {}

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Types.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Types.h
@@ -49,14 +49,14 @@ namespace Mcro::Types
 		
 	protected:
 		FName TypeName;
-		uint64 TypeHash = 0;
+		FType TypeInfo;
 
 		/** @brief This function needs to be called on top level derived type for runtime reflection to work */
 		template <typename Self>
 		void SetType(this Self&& self)
 		{
 			self.TypeName = TTypeFName<Self>();
-			self.TypeHash = TTypeHash<Self>;
+			self.TypeInfo = TTypeOf<Self>;
 		}
 		
 	public:
@@ -71,8 +71,9 @@ namespace Mcro::Types
 			return SharedThis(&self);
 		}
 
-		FORCEINLINE FName const& GetType() const { return TypeName; }
-		FORCEINLINE uint64 GetTypeHash() const { return TypeHash; }
+		FORCEINLINE FType const& GetType() const { return TypeInfo; }
+		FORCEINLINE FName const& GetTypeFName() const { return TypeName; }
+		FORCEINLINE FString GetTypeString() const { return TypeName.ToString(); }
 
 		/**
 		 *	@brief  Very simple dynamic casting of this object to a derived top-level type.
@@ -88,7 +89,7 @@ namespace Mcro::Types
 		TSharedPtr<Derived> AsExactly(this Self&& self)
 		{
 			if constexpr (CDerivedFrom<Derived, Self>)
-				if (self.TypeHash == TTypeHash<Derived>)
+				if (self.TypeInfo == TTypeOf<Derived>)
 					return StaticCastSharedPtr<Derived>(
 						SharedThis(AsMutablePtr(&self)).ToSharedPtr()
 					);

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/Types.h
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/Types.h
@@ -37,6 +37,10 @@ namespace Mcro::Types
 	 *	Once that's available we can gather base classes in compile time, and do dynamic casting of objects without
 	 *	the need for intrusive extra syntax, or extra work at construction.
 	 *	Currently GCC's `__bases` would be perfect for the job, but other popular compilers don't have similar intrinsics.
+	 *
+	 *	@warning
+	 *	Do not use exact type comparison with serialized data or network communication, as the actual value of the type
+	 *	is different between compilers. Only use this for runtime data. For such scenarios just use Unreal's own UObjects.
 	 */
 	class IHaveType : public TSharedFromThis<IHaveType>
 	{
@@ -45,12 +49,14 @@ namespace Mcro::Types
 		
 	protected:
 		FName TypeName;
+		uint64 TypeHash = 0;
 
 		/** @brief This function needs to be called on top level derived type for runtime reflection to work */
 		template <typename Self>
 		void SetType(this Self&& self)
 		{
 			self.TypeName = TTypeFName<Self>();
+			self.TypeHash = TTypeHash<Self>;
 		}
 		
 	public:
@@ -66,6 +72,7 @@ namespace Mcro::Types
 		}
 
 		FORCEINLINE FName const& GetType() const { return TypeName; }
+		FORCEINLINE uint64 GetTypeHash() const { return TypeHash; }
 
 		/**
 		 *	@brief  Very simple dynamic casting of this object to a derived top-level type.
@@ -73,7 +80,7 @@ namespace Mcro::Types
 		 *	@tparam Derived
 		 *	Only return the desired type when the current object is exactly that type, and doesn't have deeper
 		 *	inheritance. Proper dynamic casting regarding the entire inheritance tree still without RTTI will come once
-		 *	proposed C++26 value-typed reflection becomes available.
+		 *	proposed C++26 value-typed reflection becomes wide-spread available among popular compilers.
 		 *
 		 *	@return  Object cast to desired type when that's possible (see `Derived`) or nullptr;
 		 */
@@ -81,7 +88,7 @@ namespace Mcro::Types
 		TSharedPtr<Derived> AsExactly(this Self&& self)
 		{
 			if constexpr (CDerivedFrom<Derived, Self>)
-				if (self.TypeName == TTypeFName<Derived>())
+				if (self.TypeHash == TTypeHash<Derived>)
 					return StaticCastSharedPtr<Derived>(
 						SharedThis(AsMutablePtr(&self)).ToSharedPtr()
 					);

--- a/Source/Mcro/Mcro_Origin/Public/Mcro/xxHash.tp.yml
+++ b/Source/Mcro/Mcro_Origin/Public/Mcro/xxHash.tp.yml
@@ -1,0 +1,13 @@
+﻿name: xxHash
+source: https://github.com/Cyan4973/xxHash
+project: https://xxhash.com
+authors:
+    - Yann Collet (http://fastcompression.blogspot.fr/)
+    - Easy as PI 3.14 (https://github.com/easyaspi314)
+    - Takayuki Matsuoka
+    - et. al.
+license: BSD 2-Clause License (https://github.com/Cyan4973/xxHash/blob/dev/LICENSE)
+reasoning: |
+    xxHash algorithm is used by another third-party implementation in constexpr time. This allows us to have almost free
+    runtime exact type checking.
+    

--- a/UseMcro.nuke.cs
+++ b/UseMcro.nuke.cs
@@ -38,3 +38,17 @@ public interface IUseMcro : INukeBuild
         );
     }
 }
+
+[ImplicitBuildInterface]
+public interface IImplicitMcroTargets : INukeBuild
+{
+    Target GenerateMcroDocs => _ => _
+        .Triggers<IMcroLicenseRegion>(_ => _.RenderMcroAttribution)
+        .Executes(() =>
+        {
+            ToolResolver.GetPathTool("doxygen")(
+                (this.ScriptFolder() / "Doxyfile").ToString(),
+                workingDirectory: this.ScriptFolder()
+            );
+        });
+}


### PR DESCRIPTION
* `FAny` (which is an improvement over `boost::any` or `std::any` both of which rely on RTTI and exceptions (boost one has non-RTTI, but still rely on exceptions and doesn't have features like `FAny`)
* `IComposable` family of classes and utilities
* `IError` uses FMT style text formatting
* \+ constexpr xxhash
* \+ Test helpers
* various smaller improvements